### PR TITLE
Phase 4: Polish, hardening & observability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
         <!-- Spring AI - Anthropic -->
         <dependency>

--- a/src/main/java/com/dbbaskette/issuebot/controller/CostController.java
+++ b/src/main/java/com/dbbaskette/issuebot/controller/CostController.java
@@ -1,0 +1,91 @@
+package com.dbbaskette.issuebot.controller;
+
+import com.dbbaskette.issuebot.model.IssueStatus;
+import com.dbbaskette.issuebot.model.TrackedIssue;
+import com.dbbaskette.issuebot.model.WatchedRepo;
+import com.dbbaskette.issuebot.repository.CostTrackingRepository;
+import com.dbbaskette.issuebot.repository.TrackedIssueRepository;
+import com.dbbaskette.issuebot.repository.WatchedRepoRepository;
+import com.dbbaskette.issuebot.service.polling.IssuePollingService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+public class CostController {
+
+    private final CostTrackingRepository costRepository;
+    private final TrackedIssueRepository issueRepository;
+    private final WatchedRepoRepository repoRepository;
+    private final IssuePollingService pollingService;
+
+    public CostController(CostTrackingRepository costRepository,
+                           TrackedIssueRepository issueRepository,
+                           WatchedRepoRepository repoRepository,
+                           IssuePollingService pollingService) {
+        this.costRepository = costRepository;
+        this.issueRepository = issueRepository;
+        this.repoRepository = repoRepository;
+        this.pollingService = pollingService;
+    }
+
+    @GetMapping("/costs")
+    public String costs(Model model) {
+        model.addAttribute("activePage", "costs");
+        model.addAttribute("contentTemplate", "costs");
+        model.addAttribute("agentRunning", pollingService.isEnabled());
+        model.addAttribute("pendingApprovals", issueRepository.countByStatus(IssueStatus.AWAITING_APPROVAL));
+
+        // Global totals
+        BigDecimal totalCost = costRepository.findAll().stream()
+                .map(c -> c.getEstimatedCost())
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        long totalInput = costRepository.totalInputTokens();
+        long totalOutput = costRepository.totalOutputTokens();
+
+        model.addAttribute("totalCost", totalCost);
+        model.addAttribute("totalInputTokens", totalInput);
+        model.addAttribute("totalOutputTokens", totalOutput);
+        model.addAttribute("totalTokens", totalInput + totalOutput);
+
+        // Per-repo breakdown
+        List<RepoBreakdown> repoBreakdowns = new ArrayList<>();
+        for (WatchedRepo repo : repoRepository.findAll()) {
+            BigDecimal repoCost = costRepository.totalCostForRepo(repo);
+            long issueCount = issueRepository.findByRepo(repo).stream()
+                    .filter(i -> i.getStatus() == IssueStatus.COMPLETED || i.getStatus() == IssueStatus.FAILED)
+                    .count();
+            BigDecimal avgCost = issueCount > 0
+                    ? repoCost.divide(BigDecimal.valueOf(issueCount), 4, RoundingMode.HALF_UP)
+                    : BigDecimal.ZERO;
+            repoBreakdowns.add(new RepoBreakdown(repo.fullName(), repoCost, issueCount, avgCost));
+        }
+        model.addAttribute("repoBreakdowns", repoBreakdowns);
+
+        // Per-issue breakdown (recent completed/failed issues)
+        List<IssueBreakdown> issueBreakdowns = new ArrayList<>();
+        List<TrackedIssue> recentIssues = issueRepository.findByStatusIn(
+                List.of(IssueStatus.COMPLETED, IssueStatus.FAILED, IssueStatus.IN_PROGRESS));
+        for (TrackedIssue issue : recentIssues) {
+            BigDecimal issueCost = costRepository.totalCostForIssue(issue);
+            issueBreakdowns.add(new IssueBreakdown(
+                    issue.getRepo().fullName(),
+                    issue.getIssueNumber(),
+                    issue.getIssueTitle(),
+                    issue.getStatus().name(),
+                    issue.getCurrentIteration(),
+                    issueCost));
+        }
+        model.addAttribute("issueBreakdowns", issueBreakdowns);
+
+        return "layout";
+    }
+
+    public record RepoBreakdown(String repoName, BigDecimal totalCost, long issueCount, BigDecimal avgCostPerIssue) {}
+    public record IssueBreakdown(String repoName, int issueNumber, String title, String status, int iterations, BigDecimal cost) {}
+}

--- a/src/main/java/com/dbbaskette/issuebot/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/dbbaskette/issuebot/controller/GlobalExceptionHandler.java
@@ -1,0 +1,56 @@
+package com.dbbaskette.issuebot.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import java.util.NoSuchElementException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(NoSuchElementException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleNotFound(NoSuchElementException e, Model model) {
+        log.warn("Resource not found: {}", e.getMessage());
+        model.addAttribute("activePage", "");
+        model.addAttribute("contentTemplate", "error");
+        model.addAttribute("errorTitle", "Not Found");
+        model.addAttribute("errorMessage", "The requested resource was not found.");
+        model.addAttribute("agentRunning", true);
+        model.addAttribute("pendingApprovals", 0L);
+        return "layout";
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleNoResource(NoResourceFoundException e, Model model) {
+        model.addAttribute("activePage", "");
+        model.addAttribute("contentTemplate", "error");
+        model.addAttribute("errorTitle", "Not Found");
+        model.addAttribute("errorMessage", "Page not found.");
+        model.addAttribute("agentRunning", true);
+        model.addAttribute("pendingApprovals", 0L);
+        return "layout";
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public String handleGeneral(Exception e, Model model) {
+        log.error("Unhandled exception", e);
+        model.addAttribute("activePage", "");
+        model.addAttribute("contentTemplate", "error");
+        model.addAttribute("errorTitle", "Error");
+        model.addAttribute("errorMessage", "An unexpected error occurred: " + e.getMessage());
+        model.addAttribute("agentRunning", true);
+        model.addAttribute("pendingApprovals", 0L);
+        return "layout";
+    }
+}

--- a/src/main/java/com/dbbaskette/issuebot/controller/SetupController.java
+++ b/src/main/java/com/dbbaskette/issuebot/controller/SetupController.java
@@ -1,0 +1,75 @@
+package com.dbbaskette.issuebot.controller;
+
+import com.dbbaskette.issuebot.config.IssueBotProperties;
+import com.dbbaskette.issuebot.model.IssueStatus;
+import com.dbbaskette.issuebot.repository.TrackedIssueRepository;
+import com.dbbaskette.issuebot.service.claude.ClaudeCodeService;
+import com.dbbaskette.issuebot.service.polling.IssuePollingService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.io.File;
+
+@Controller
+public class SetupController {
+
+    private final ClaudeCodeService claudeCodeService;
+    private final IssueBotProperties properties;
+    private final IssuePollingService pollingService;
+    private final TrackedIssueRepository issueRepository;
+
+    public SetupController(ClaudeCodeService claudeCodeService,
+                            IssueBotProperties properties,
+                            IssuePollingService pollingService,
+                            TrackedIssueRepository issueRepository) {
+        this.claudeCodeService = claudeCodeService;
+        this.properties = properties;
+        this.pollingService = pollingService;
+        this.issueRepository = issueRepository;
+    }
+
+    @GetMapping("/setup")
+    public String setup(Model model) {
+        model.addAttribute("activePage", "setup");
+        model.addAttribute("contentTemplate", "setup");
+        model.addAttribute("agentRunning", pollingService.isEnabled());
+        model.addAttribute("pendingApprovals", issueRepository.countByStatus(IssueStatus.AWAITING_APPROVAL));
+
+        // Prerequisites checks
+        boolean cliAvailable = claudeCodeService.isCliAvailable();
+        model.addAttribute("cliAvailable", cliAvailable);
+
+        boolean cliAuthenticated = false;
+        if (cliAvailable) {
+            cliAuthenticated = claudeCodeService.checkAuthentication();
+        }
+        model.addAttribute("cliAuthenticated", cliAuthenticated);
+
+        String token = properties.getGithub().getToken();
+        boolean githubTokenSet = token != null && !token.isBlank() && !"not-set".equals(token);
+        model.addAttribute("githubTokenSet", githubTokenSet);
+
+        // Work directory check
+        File workDir = new File(properties.getWorkDirectory());
+        boolean workDirOk;
+        String workDirMessage;
+        if (workDir.exists()) {
+            long freeSpaceMb = workDir.getFreeSpace() / (1024 * 1024);
+            workDirOk = freeSpaceMb > 500;
+            workDirMessage = workDir.getAbsolutePath() + " (" + freeSpaceMb + " MB free)";
+        } else {
+            boolean created = workDir.mkdirs();
+            workDirOk = created;
+            workDirMessage = created
+                    ? workDir.getAbsolutePath() + " (created)"
+                    : "Could not create " + workDir.getAbsolutePath();
+        }
+        model.addAttribute("workDirOk", workDirOk);
+        model.addAttribute("workDirMessage", workDirMessage);
+
+        model.addAttribute("allPassed", cliAvailable && cliAuthenticated && githubTokenSet && workDirOk);
+
+        return "layout";
+    }
+}

--- a/src/main/java/com/dbbaskette/issuebot/observability/GitHubHealthIndicator.java
+++ b/src/main/java/com/dbbaskette/issuebot/observability/GitHubHealthIndicator.java
@@ -1,0 +1,41 @@
+package com.dbbaskette.issuebot.observability;
+
+import com.dbbaskette.issuebot.config.IssueBotProperties;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component("gitHub")
+public class GitHubHealthIndicator implements HealthIndicator {
+
+    private final WebClient webClient;
+    private final IssueBotProperties properties;
+
+    public GitHubHealthIndicator(WebClient gitHubWebClient, IssueBotProperties properties) {
+        this.webClient = gitHubWebClient;
+        this.properties = properties;
+    }
+
+    @Override
+    public Health health() {
+        String token = properties.getGithub().getToken();
+        if (token == null || token.isBlank() || "not-set".equals(token)) {
+            return Health.down().withDetail("reason", "GitHub token not configured").build();
+        }
+
+        try {
+            webClient.get()
+                    .uri("/rate_limit")
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block(java.time.Duration.ofSeconds(5));
+            return Health.up().withDetail("api", "reachable").build();
+        } catch (Exception e) {
+            return Health.down()
+                    .withDetail("reason", "GitHub API unreachable")
+                    .withDetail("error", e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/dbbaskette/issuebot/observability/IssueBotHealthIndicator.java
+++ b/src/main/java/com/dbbaskette/issuebot/observability/IssueBotHealthIndicator.java
@@ -1,0 +1,55 @@
+package com.dbbaskette.issuebot.observability;
+
+import com.dbbaskette.issuebot.config.IssueBotProperties;
+import com.dbbaskette.issuebot.service.claude.ClaudeCodeService;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+
+@Component("issueBot")
+public class IssueBotHealthIndicator implements HealthIndicator {
+
+    private final ClaudeCodeService claudeCodeService;
+    private final IssueBotProperties properties;
+
+    public IssueBotHealthIndicator(ClaudeCodeService claudeCodeService,
+                                    IssueBotProperties properties) {
+        this.claudeCodeService = claudeCodeService;
+        this.properties = properties;
+    }
+
+    @Override
+    public Health health() {
+        Health.Builder builder = Health.up();
+
+        // Claude Code CLI
+        boolean cliAvailable = claudeCodeService.isCliAvailable();
+        builder.withDetail("claudeCodeCli", cliAvailable ? "available" : "unavailable");
+
+        // GitHub token configured
+        String token = properties.getGithub().getToken();
+        boolean tokenSet = token != null && !token.isBlank() && !"not-set".equals(token);
+        builder.withDetail("githubToken", tokenSet ? "configured" : "missing");
+
+        // Work directory disk space
+        File workDir = new File(properties.getWorkDirectory());
+        if (workDir.exists()) {
+            long freeSpaceMb = workDir.getFreeSpace() / (1024 * 1024);
+            builder.withDetail("workDirFreeSpaceMb", freeSpaceMb);
+            if (freeSpaceMb < 500) {
+                builder.down().withDetail("warning", "Low disk space on work directory");
+            }
+        }
+
+        // Watched repos count
+        builder.withDetail("watchedRepos", properties.getRepositories().size());
+
+        if (!cliAvailable || !tokenSet) {
+            builder.status("DEGRADED");
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/dbbaskette/issuebot/observability/IssueBotMetrics.java
+++ b/src/main/java/com/dbbaskette/issuebot/observability/IssueBotMetrics.java
@@ -1,0 +1,96 @@
+package com.dbbaskette.issuebot.observability;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Centralized Micrometer metrics for IssueBot.
+ */
+@Component
+public class IssueBotMetrics {
+
+    private final Counter issuesCompleted;
+    private final Counter issuesFailed;
+    private final Counter issuesDetected;
+    private final Counter claudeInvocations;
+    private final Counter inputTokensTotal;
+    private final Counter outputTokensTotal;
+    private final Counter githubApiCalls;
+    private final Timer claudeCodeDuration;
+    private final Timer ciWaitDuration;
+    private final AtomicInteger activeSessionsGauge;
+    private final MeterRegistry registry;
+
+    public IssueBotMetrics(MeterRegistry registry) {
+        this.registry = registry;
+
+        this.issuesCompleted = Counter.builder("issuebot.issues.completed")
+                .description("Total issues completed successfully")
+                .register(registry);
+
+        this.issuesFailed = Counter.builder("issuebot.issues.failed")
+                .description("Total issues that failed after max iterations")
+                .register(registry);
+
+        this.issuesDetected = Counter.builder("issuebot.issues.detected")
+                .description("Total issues detected for processing")
+                .register(registry);
+
+        this.claudeInvocations = Counter.builder("issuebot.claude.invocations")
+                .description("Total Claude Code CLI invocations")
+                .register(registry);
+
+        this.inputTokensTotal = Counter.builder("issuebot.claude.tokens.input")
+                .description("Total input tokens consumed")
+                .register(registry);
+
+        this.outputTokensTotal = Counter.builder("issuebot.claude.tokens.output")
+                .description("Total output tokens consumed")
+                .register(registry);
+
+        this.githubApiCalls = Counter.builder("issuebot.github.api.calls")
+                .description("Total GitHub API calls made")
+                .register(registry);
+
+        this.claudeCodeDuration = Timer.builder("issuebot.claude.duration")
+                .description("Claude Code CLI execution duration")
+                .register(registry);
+
+        this.ciWaitDuration = Timer.builder("issuebot.ci.wait.duration")
+                .description("Time spent waiting for CI checks")
+                .register(registry);
+
+        this.activeSessionsGauge = registry.gauge("issuebot.claude.active_sessions",
+                new AtomicInteger(0));
+    }
+
+    public void recordIssueCompleted() { issuesCompleted.increment(); }
+    public void recordIssueFailed() { issuesFailed.increment(); }
+    public void recordIssueDetected() { issuesDetected.increment(); }
+
+    public void recordClaudeInvocation(long durationMs, long inputTokens, long outputTokens) {
+        claudeInvocations.increment();
+        claudeCodeDuration.record(Duration.ofMillis(durationMs));
+        inputTokensTotal.increment(inputTokens);
+        outputTokensTotal.increment(outputTokens);
+    }
+
+    public void recordCiWait(long durationMs) {
+        ciWaitDuration.record(Duration.ofMillis(durationMs));
+    }
+
+    public void recordGitHubApiCall() { githubApiCalls.increment(); }
+
+    public void incrementActiveSessions() {
+        if (activeSessionsGauge != null) activeSessionsGauge.incrementAndGet();
+    }
+
+    public void decrementActiveSessions() {
+        if (activeSessionsGauge != null) activeSessionsGauge.decrementAndGet();
+    }
+}

--- a/src/main/java/com/dbbaskette/issuebot/repository/CostTrackingRepository.java
+++ b/src/main/java/com/dbbaskette/issuebot/repository/CostTrackingRepository.java
@@ -2,6 +2,7 @@ package com.dbbaskette.issuebot.repository;
 
 import com.dbbaskette.issuebot.model.CostTracking;
 import com.dbbaskette.issuebot.model.TrackedIssue;
+import com.dbbaskette.issuebot.model.WatchedRepo;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import java.math.BigDecimal;
@@ -13,4 +14,15 @@ public interface CostTrackingRepository extends JpaRepository<CostTracking, Long
 
     @Query("SELECT COALESCE(SUM(c.estimatedCost), 0) FROM CostTracking c WHERE c.issue = :issue")
     BigDecimal totalCostForIssue(TrackedIssue issue);
+
+    @Query("SELECT COALESCE(SUM(c.estimatedCost), 0) FROM CostTracking c WHERE c.issue.repo = :repo")
+    BigDecimal totalCostForRepo(WatchedRepo repo);
+
+    @Query("SELECT COALESCE(SUM(c.inputTokens), 0) FROM CostTracking c")
+    long totalInputTokens();
+
+    @Query("SELECT COALESCE(SUM(c.outputTokens), 0) FROM CostTracking c")
+    long totalOutputTokens();
+
+    List<CostTracking> findByIssueRepoOrderByIdDesc(WatchedRepo repo);
 }

--- a/src/main/java/com/dbbaskette/issuebot/security/BranchNameValidator.java
+++ b/src/main/java/com/dbbaskette/issuebot/security/BranchNameValidator.java
@@ -1,0 +1,30 @@
+package com.dbbaskette.issuebot.security;
+
+import java.util.regex.Pattern;
+
+/**
+ * Validates branch names to ensure IssueBot only operates on its own branches.
+ */
+public final class BranchNameValidator {
+
+    private static final Pattern ISSUEBOT_BRANCH = Pattern.compile("^issuebot/issue-\\d+-[a-z0-9-]+$");
+
+    private BranchNameValidator() {}
+
+    /**
+     * Check if a branch name matches the IssueBot naming convention.
+     */
+    public static boolean isValid(String branchName) {
+        return branchName != null && ISSUEBOT_BRANCH.matcher(branchName).matches();
+    }
+
+    /**
+     * Ensure a branch is not the default/protected branch.
+     */
+    public static boolean isSafeToPush(String branchName, String defaultBranch) {
+        if (branchName == null) return false;
+        if (branchName.equals(defaultBranch)) return false;
+        if ("main".equals(branchName) || "master".equals(branchName)) return false;
+        return isValid(branchName);
+    }
+}

--- a/src/main/java/com/dbbaskette/issuebot/security/LogSanitizer.java
+++ b/src/main/java/com/dbbaskette/issuebot/security/LogSanitizer.java
@@ -1,0 +1,25 @@
+package com.dbbaskette.issuebot.security;
+
+import java.util.regex.Pattern;
+
+/**
+ * Sanitizes log output to redact API keys and tokens.
+ */
+public final class LogSanitizer {
+
+    private static final Pattern GITHUB_TOKEN = Pattern.compile("(ghp_[A-Za-z0-9_]{36,})");
+    private static final Pattern ANTHROPIC_KEY = Pattern.compile("(sk-ant-[A-Za-z0-9_-]{20,})");
+    private static final Pattern BEARER_TOKEN = Pattern.compile("(Bearer\\s+)[A-Za-z0-9._-]+");
+    private static final Pattern GENERIC_SECRET = Pattern.compile("((?:token|key|secret|password)\\s*[:=]\\s*)\\S+", Pattern.CASE_INSENSITIVE);
+
+    private LogSanitizer() {}
+
+    public static String sanitize(String input) {
+        if (input == null) return null;
+        String result = input;
+        result = GITHUB_TOKEN.matcher(result).replaceAll("ghp_***REDACTED***");
+        result = ANTHROPIC_KEY.matcher(result).replaceAll("sk-ant-***REDACTED***");
+        result = BEARER_TOKEN.matcher(result).replaceAll("$1***REDACTED***");
+        return result;
+    }
+}

--- a/src/main/java/com/dbbaskette/issuebot/security/SecurityConfig.java
+++ b/src/main/java/com/dbbaskette/issuebot/security/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.dbbaskette.issuebot.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll()
+            )
+            .csrf(csrf -> csrf
+                .ignoringRequestMatchers("/api/**", "/h2-console/**")
+            )
+            .headers(headers -> headers
+                .frameOptions(frame -> frame.sameOrigin()) // Allow H2 console iframe
+            );
+        return http.build();
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- Console output for development -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- JSON file output for production observability -->
+    <appender name="JSON_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${user.home}/.issuebot/logs/issuebot.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${user.home}/.issuebot/logs/issuebot.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+            <totalSizeCap>500MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ} [%thread] %-5level %logger{40} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Reduce noise from framework loggers -->
+    <logger name="org.springframework" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="org.flywaydb" level="INFO"/>
+    <logger name="org.eclipse.jgit" level="WARN"/>
+    <logger name="io.micrometer" level="WARN"/>
+
+    <!-- IssueBot loggers at DEBUG for troubleshooting -->
+    <logger name="com.dbbaskette.issuebot" level="DEBUG"/>
+
+    <!-- Default profile: console only -->
+    <springProfile name="default">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!-- Production profile: console + file -->
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="JSON_FILE"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/src/main/resources/templates/costs.html
+++ b/src/main/resources/templates/costs.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="content">
+    <div class="page-header">
+        <h2>Cost Report</h2>
+    </div>
+
+    <div class="metrics-grid">
+        <div class="metric-card">
+            <div class="label">Total Cost</div>
+            <div class="value small" th:text="'$' + ${#numbers.formatDecimal(totalCost, 1, 4)}">$0.0000</div>
+        </div>
+        <div class="metric-card">
+            <div class="label">Input Tokens</div>
+            <div class="value" th:text="${#numbers.formatInteger(totalInputTokens, 1, 'COMMA')}">0</div>
+        </div>
+        <div class="metric-card">
+            <div class="label">Output Tokens</div>
+            <div class="value" th:text="${#numbers.formatInteger(totalOutputTokens, 1, 'COMMA')}">0</div>
+        </div>
+        <div class="metric-card">
+            <div class="label">Total Tokens</div>
+            <div class="value" th:text="${#numbers.formatInteger(totalTokens, 1, 'COMMA')}">0</div>
+        </div>
+    </div>
+
+    <!-- Per-repo breakdown -->
+    <div class="panel mb-3">
+        <div class="panel-header">
+            <h3>Cost by Repository</h3>
+        </div>
+        <div class="panel-body">
+            <table class="data-table" th:if="${not #lists.isEmpty(repoBreakdowns)}">
+                <thead>
+                    <tr>
+                        <th>Repository</th>
+                        <th>Issues Processed</th>
+                        <th>Total Cost</th>
+                        <th>Avg Cost / Issue</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr th:each="rb : ${repoBreakdowns}">
+                        <td th:text="${rb.repoName()}">owner/repo</td>
+                        <td th:text="${rb.issueCount()}">0</td>
+                        <td th:text="'$' + ${#numbers.formatDecimal(rb.totalCost(), 1, 4)}">$0.0000</td>
+                        <td th:text="'$' + ${#numbers.formatDecimal(rb.avgCostPerIssue(), 1, 4)}">$0.0000</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p class="text-muted" th:if="${#lists.isEmpty(repoBreakdowns)}">No repositories with cost data yet.</p>
+        </div>
+    </div>
+
+    <!-- Per-issue breakdown -->
+    <div class="panel">
+        <div class="panel-header">
+            <h3>Cost by Issue</h3>
+        </div>
+        <div class="panel-body">
+            <table class="data-table" th:if="${not #lists.isEmpty(issueBreakdowns)}">
+                <thead>
+                    <tr>
+                        <th>Repository</th>
+                        <th>Issue</th>
+                        <th>Status</th>
+                        <th>Iterations</th>
+                        <th>Cost</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr th:each="ib : ${issueBreakdowns}">
+                        <td th:text="${ib.repoName()}">owner/repo</td>
+                        <td>
+                            <a th:href="@{/issues/{id}(id=${ib.issueNumber()})}"
+                               th:text="'#' + ${ib.issueNumber()} + ' ' + ${ib.title()}">
+                                #1 Title
+                            </a>
+                        </td>
+                        <td>
+                            <span class="status"
+                                  th:classappend="'status-' + ${ib.status().toLowerCase()}"
+                                  th:text="${ib.status()}">STATUS</span>
+                        </td>
+                        <td th:text="${ib.iterations()}">0</td>
+                        <td th:text="'$' + ${#numbers.formatDecimal(ib.cost(), 1, 4)}">$0.0000</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p class="text-muted" th:if="${#lists.isEmpty(issueBreakdowns)}">No issues with cost data yet.</p>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="content">
+    <div class="page-header">
+        <h2 th:text="${errorTitle}">Error</h2>
+    </div>
+    <div class="panel">
+        <div class="panel-body" style="text-align:center;padding:3rem">
+            <p th:text="${errorMessage}" style="font-size:1.1rem">An error occurred.</p>
+            <a href="/" class="btn btn-primary mt-2">Back to Dashboard</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -24,7 +24,9 @@
                     <span th:if="${pendingApprovals != null and pendingApprovals > 0}" class="badge" th:text="${pendingApprovals}">0</span>
                 </a>
             </li>
+            <li><a th:classappend="${activePage == 'costs' ? 'active' : ''}" href="/costs" hx-get="/costs" hx-target="#content" hx-push-url="true">Cost Report</a></li>
             <li><a th:classappend="${activePage == 'settings' ? 'active' : ''}" href="/settings" hx-get="/settings" hx-target="#content" hx-push-url="true">Settings</a></li>
+            <li><a th:classappend="${activePage == 'setup' ? 'active' : ''}" href="/setup" hx-get="/setup" hx-target="#content" hx-push-url="true">Setup</a></li>
         </ul>
         <footer>
             <div class="agent-status">

--- a/src/main/resources/templates/setup.html
+++ b/src/main/resources/templates/setup.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="content">
+    <div class="page-header">
+        <h2>Setup Wizard</h2>
+    </div>
+
+    <div class="panel mb-3">
+        <div class="panel-header">
+            <h3>Prerequisites Check</h3>
+        </div>
+        <div class="panel-body">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Component</th>
+                        <th>Status</th>
+                        <th>Details</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Claude Code CLI</td>
+                        <td>
+                            <span class="status" th:classappend="${cliAvailable ? 'status-completed' : 'status-failed'}"
+                                  th:text="${cliAvailable ? 'OK' : 'MISSING'}">OK</span>
+                        </td>
+                        <td th:if="${cliAvailable}">Claude Code CLI is installed and accessible.</td>
+                        <td th:unless="${cliAvailable}">
+                            Install Claude Code: <code>npm install -g @anthropic-ai/claude-code</code>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Claude Code Auth</td>
+                        <td>
+                            <span class="status" th:classappend="${cliAuthenticated ? 'status-completed' : 'status-failed'}"
+                                  th:text="${cliAuthenticated ? 'OK' : 'FAILED'}">OK</span>
+                        </td>
+                        <td th:if="${cliAuthenticated}">Authentication verified.</td>
+                        <td th:unless="${cliAuthenticated}">
+                            Set <code>ANTHROPIC_API_KEY</code> environment variable.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>GitHub Token</td>
+                        <td>
+                            <span class="status" th:classappend="${githubTokenSet ? 'status-completed' : 'status-failed'}"
+                                  th:text="${githubTokenSet ? 'OK' : 'MISSING'}">OK</span>
+                        </td>
+                        <td th:if="${githubTokenSet}">GitHub token is configured.</td>
+                        <td th:unless="${githubTokenSet}">
+                            Set <code>GITHUB_TOKEN</code> environment variable with <code>repo</code> scope.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Work Directory</td>
+                        <td>
+                            <span class="status" th:classappend="${workDirOk ? 'status-completed' : 'status-failed'}"
+                                  th:text="${workDirOk ? 'OK' : 'ISSUE'}">OK</span>
+                        </td>
+                        <td th:text="${workDirMessage}">Work directory details</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="panel mb-3">
+        <div class="panel-header">
+            <h3>Quick Start</h3>
+        </div>
+        <div class="panel-body">
+            <p th:if="${allPassed}" style="color: var(--color-completed); font-weight: 600;">
+                All prerequisites are met. You're ready to go!
+            </p>
+            <p th:unless="${allPassed}" style="color: var(--color-failed); font-weight: 600;">
+                Some prerequisites are not met. Please resolve the issues above.
+            </p>
+
+            <h4 class="mt-2">Next Steps</h4>
+            <ol>
+                <li>Go to <a href="/repositories">Repositories</a> and add a GitHub repository to watch.</li>
+                <li>On your GitHub repo, add the label <code>agent-ready</code> to an issue you want IssueBot to work on.</li>
+                <li>IssueBot will detect the issue and begin implementation automatically.</li>
+                <li>Monitor progress on the <a href="/">Dashboard</a>.</li>
+            </ol>
+        </div>
+    </div>
+
+    <div class="panel">
+        <div class="panel-header">
+            <h3>Configuration File</h3>
+        </div>
+        <div class="panel-body">
+            <p class="text-sm text-muted mb-2">
+                IssueBot looks for a config file at <code>~/.issuebot/config.yml</code>.
+                Below is an example configuration:
+            </p>
+            <pre class="diff-viewer">issuebot:
+  poll-interval-seconds: 60
+  max-concurrent-issues: 3
+  work-directory: ${user.home}/.issuebot/repos
+  claude-code:
+    max-turns-per-invocation: 30
+    model: claude-sonnet-4-5-20250929
+    timeout-minutes: 10
+  github:
+    token: ${GITHUB_TOKEN}
+  notifications:
+    desktop: true
+    dashboard: true
+  repositories:
+    - owner: your-org
+      name: your-repo
+      branch: main
+      mode: autonomous
+      max-iterations: 5
+      ci-timeout-minutes: 15</pre>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/com/dbbaskette/issuebot/security/BranchNameValidatorTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/security/BranchNameValidatorTest.java
@@ -1,0 +1,54 @@
+package com.dbbaskette.issuebot.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BranchNameValidatorTest {
+
+    @Test
+    void validBranch() {
+        assertTrue(BranchNameValidator.isValid("issuebot/issue-42-fix-login-bug"));
+        assertTrue(BranchNameValidator.isValid("issuebot/issue-1-a"));
+        assertTrue(BranchNameValidator.isValid("issuebot/issue-999-add-feature-123"));
+    }
+
+    @Test
+    void invalidBranch_wrongPrefix() {
+        assertFalse(BranchNameValidator.isValid("feature/issue-42-fix-login-bug"));
+        assertFalse(BranchNameValidator.isValid("main"));
+        assertFalse(BranchNameValidator.isValid("master"));
+    }
+
+    @Test
+    void invalidBranch_noNumber() {
+        assertFalse(BranchNameValidator.isValid("issuebot/issue--fix"));
+        assertFalse(BranchNameValidator.isValid("issuebot/issue-abc-fix"));
+    }
+
+    @Test
+    void invalidBranch_null() {
+        assertFalse(BranchNameValidator.isValid(null));
+    }
+
+    @Test
+    void isSafeToPush_valid() {
+        assertTrue(BranchNameValidator.isSafeToPush("issuebot/issue-42-fix-login-bug", "main"));
+    }
+
+    @Test
+    void isSafeToPush_protectedBranch() {
+        assertFalse(BranchNameValidator.isSafeToPush("main", "main"));
+        assertFalse(BranchNameValidator.isSafeToPush("master", "main"));
+    }
+
+    @Test
+    void isSafeToPush_defaultBranch() {
+        assertFalse(BranchNameValidator.isSafeToPush("develop", "develop"));
+    }
+
+    @Test
+    void isSafeToPush_null() {
+        assertFalse(BranchNameValidator.isSafeToPush(null, "main"));
+    }
+}

--- a/src/test/java/com/dbbaskette/issuebot/security/LogSanitizerTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/security/LogSanitizerTest.java
@@ -1,0 +1,43 @@
+package com.dbbaskette.issuebot.security;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LogSanitizerTest {
+
+    @Test
+    void redactsGitHubToken() {
+        String input = "Using token ghp_ABCDEFghijklmnop1234567890abcdef12345";
+        String result = LogSanitizer.sanitize(input);
+        assertTrue(result.contains("ghp_***REDACTED***"));
+        assertFalse(result.contains("ABCDEFghijklmnop"));
+    }
+
+    @Test
+    void redactsAnthropicKey() {
+        String input = "API key: sk-ant-api03-abcdefgh1234567890";
+        String result = LogSanitizer.sanitize(input);
+        assertTrue(result.contains("sk-ant-***REDACTED***"));
+        assertFalse(result.contains("abcdefgh1234567890"));
+    }
+
+    @Test
+    void redactsBearerToken() {
+        String input = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.abc123";
+        String result = LogSanitizer.sanitize(input);
+        assertTrue(result.contains("Bearer ***REDACTED***"));
+        assertFalse(result.contains("eyJhbGciOiJIUzI1NiJ9"));
+    }
+
+    @Test
+    void nullInput() {
+        assertNull(LogSanitizer.sanitize(null));
+    }
+
+    @Test
+    void noSecrets() {
+        String input = "Normal log message with no secrets";
+        assertEquals(input, LogSanitizer.sanitize(input));
+    }
+}

--- a/src/test/java/com/dbbaskette/issuebot/service/workflow/IntegrationWorkflowTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/service/workflow/IntegrationWorkflowTest.java
@@ -1,0 +1,384 @@
+package com.dbbaskette.issuebot.service.workflow;
+
+import com.dbbaskette.issuebot.model.*;
+import com.dbbaskette.issuebot.repository.CostTrackingRepository;
+import com.dbbaskette.issuebot.repository.IterationRepository;
+import com.dbbaskette.issuebot.repository.TrackedIssueRepository;
+import com.dbbaskette.issuebot.service.claude.ClaudeCodeResult;
+import com.dbbaskette.issuebot.service.claude.ClaudeCodeService;
+import com.dbbaskette.issuebot.service.event.EventService;
+import com.dbbaskette.issuebot.service.git.GitOperationsService;
+import com.dbbaskette.issuebot.service.github.GitHubApiClient;
+import com.dbbaskette.issuebot.service.notification.NotificationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Integration-style tests that exercise the full IssueWorkflowService pipeline
+ * with mocked external dependencies.
+ */
+class IntegrationWorkflowTest {
+
+    private IssueWorkflowService workflowService;
+    private GitOperationsService gitOps;
+    private GitHubApiClient gitHubApi;
+    private ClaudeCodeService claudeCode;
+    private TrackedIssueRepository issueRepository;
+    private IterationRepository iterationRepository;
+    private CostTrackingRepository costRepository;
+    private EventService eventService;
+    private NotificationService notificationService;
+    private IterationManager iterationManager;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        gitOps = mock(GitOperationsService.class);
+        gitHubApi = mock(GitHubApiClient.class);
+        claudeCode = mock(ClaudeCodeService.class);
+        issueRepository = mock(TrackedIssueRepository.class);
+        iterationRepository = mock(IterationRepository.class);
+        costRepository = mock(CostTrackingRepository.class);
+        eventService = mock(EventService.class);
+        notificationService = mock(NotificationService.class);
+        iterationManager = mock(IterationManager.class);
+        objectMapper = new ObjectMapper();
+
+        workflowService = new IssueWorkflowService(
+                gitOps, gitHubApi, claudeCode,
+                issueRepository, iterationRepository, costRepository,
+                eventService, notificationService, iterationManager,
+                objectMapper);
+    }
+
+    private TrackedIssue createTestIssue() {
+        WatchedRepo repo = new WatchedRepo("owner", "repo");
+        repo.setId(1L);
+        repo.setBranch("main");
+        repo.setMode(RepoMode.AUTONOMOUS);
+        TrackedIssue issue = new TrackedIssue(repo, 42, "Fix the login bug");
+        issue.setId(1L);
+        return issue;
+    }
+
+    private ObjectNode createIssueDetails() {
+        ObjectNode details = objectMapper.createObjectNode();
+        details.put("title", "Fix the login bug");
+        details.put("body", "Users can't log in when password contains special characters");
+        details.putArray("labels");
+        return details;
+    }
+
+    private ClaudeCodeResult successResult() {
+        ClaudeCodeResult result = new ClaudeCodeResult();
+        result.setSuccess(true);
+        result.setOutput("{\"passed\": true, \"summary\": \"All good\", \"issues\": []}");
+        result.setInputTokens(1000);
+        result.setOutputTokens(500);
+        result.setModel("claude-sonnet-4-5-20250929");
+        result.setDurationMs(5000);
+        return result;
+    }
+
+    // === Test 1: Happy path — single iteration success ===
+    @Test
+    void happyPath_singleIterationSuccess() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        ObjectNode issueDetails = createIssueDetails();
+        Git mockGit = mock(Git.class);
+
+        // Setup: clone, branch, open
+        when(gitOps.cloneOrPull("owner", "repo", "main")).thenReturn(mockGit);
+        when(gitOps.createBranch(eq(mockGit), eq(42), anyString())).thenReturn("issuebot/issue-42-fix-login-bug");
+        when(gitHubApi.getIssue("owner", "repo", 42)).thenReturn(issueDetails);
+        when(gitOps.repoLocalPath("owner", "repo")).thenReturn(Path.of("/tmp/repo"));
+        when(gitOps.openRepo("owner", "repo")).thenReturn(mockGit);
+        when(gitOps.diff(any(), anyString())).thenReturn("+ added line");
+
+        // Iteration allowed once
+        when(iterationManager.canIterate(issue)).thenReturn(true, false);
+
+        // Implementation succeeds
+        when(claudeCode.executeTask(anyString(), any(Path.class), anyString(), any()))
+                .thenReturn(successResult());
+
+        // CI passes
+        when(gitHubApi.waitForChecks(eq("owner"), eq("repo"), anyString(), anyInt())).thenReturn(true);
+
+        // PR creation
+        ObjectNode prNode = objectMapper.createObjectNode();
+        prNode.put("number", 99);
+        prNode.put("html_url", "https://github.com/owner/repo/pull/99");
+        when(gitHubApi.createPullRequest(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+                .thenReturn(prNode);
+        when(costRepository.totalCostForIssue(issue)).thenReturn(BigDecimal.valueOf(0.05));
+
+        workflowService.processIssue(issue);
+
+        assertEquals(IssueStatus.COMPLETED, issue.getStatus());
+        verify(gitHubApi).createPullRequest(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq(false));
+        verify(notificationService).info(eq("Issue Completed"), anyString());
+    }
+
+    // === Test 2: Self-assessment failure triggers retry ===
+    @Test
+    void selfAssessmentFailure_triggersRetry() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        ObjectNode issueDetails = createIssueDetails();
+        Git mockGit = mock(Git.class);
+
+        when(gitOps.cloneOrPull("owner", "repo", "main")).thenReturn(mockGit);
+        when(gitOps.createBranch(eq(mockGit), eq(42), anyString())).thenReturn("issuebot/issue-42-fix-login-bug");
+        when(gitHubApi.getIssue("owner", "repo", 42)).thenReturn(issueDetails);
+        when(gitOps.repoLocalPath("owner", "repo")).thenReturn(Path.of("/tmp/repo"));
+        when(gitOps.openRepo("owner", "repo")).thenReturn(mockGit);
+        when(gitOps.diff(any(), anyString())).thenReturn("+ some changes");
+
+        // Allow 2 iterations then stop
+        when(iterationManager.canIterate(issue)).thenReturn(true, true, false);
+
+        // Implementation always succeeds
+        ClaudeCodeResult implResult = successResult();
+        implResult.setOutput("implementation done");
+
+        // First assessment: failure. Second: success
+        ClaudeCodeResult failAssessment = new ClaudeCodeResult();
+        failAssessment.setSuccess(true);
+        failAssessment.setOutput("{\"passed\": false, \"summary\": \"Missing tests\", \"issues\": [\"No tests\"]}");
+        failAssessment.setInputTokens(500);
+        failAssessment.setOutputTokens(200);
+        failAssessment.setDurationMs(3000);
+
+        ClaudeCodeResult passAssessment = new ClaudeCodeResult();
+        passAssessment.setSuccess(true);
+        passAssessment.setOutput("{\"passed\": true, \"summary\": \"All good\", \"issues\": []}");
+        passAssessment.setInputTokens(500);
+        passAssessment.setOutputTokens(200);
+        passAssessment.setDurationMs(3000);
+
+        when(claudeCode.executeTask(anyString(), any(Path.class), anyString(), any()))
+                .thenReturn(implResult);
+        when(claudeCode.executeTask(anyString(), any(Path.class), eq("Read,Bash(git diff:*)"), any()))
+                .thenReturn(failAssessment, passAssessment);
+
+        // CI passes
+        when(gitHubApi.waitForChecks(eq("owner"), eq("repo"), anyString(), anyInt())).thenReturn(true);
+
+        ObjectNode prNode = objectMapper.createObjectNode();
+        prNode.put("number", 100);
+        prNode.put("html_url", "https://github.com/owner/repo/pull/100");
+        when(gitHubApi.createPullRequest(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+                .thenReturn(prNode);
+        when(costRepository.totalCostForIssue(issue)).thenReturn(BigDecimal.valueOf(0.10));
+
+        workflowService.processIssue(issue);
+
+        // Should have iterated twice
+        assertEquals(2, issue.getCurrentIteration());
+    }
+
+    // === Test 3: CI failure triggers retry ===
+    @Test
+    void ciFailure_triggersRetry() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        ObjectNode issueDetails = createIssueDetails();
+        Git mockGit = mock(Git.class);
+
+        when(gitOps.cloneOrPull("owner", "repo", "main")).thenReturn(mockGit);
+        when(gitOps.createBranch(eq(mockGit), eq(42), anyString())).thenReturn("issuebot/issue-42-fix-login-bug");
+        when(gitHubApi.getIssue("owner", "repo", 42)).thenReturn(issueDetails);
+        when(gitOps.repoLocalPath("owner", "repo")).thenReturn(Path.of("/tmp/repo"));
+        when(gitOps.openRepo("owner", "repo")).thenReturn(mockGit);
+        when(gitOps.diff(any(), anyString())).thenReturn("+ changes");
+
+        // Only 1 iteration allowed
+        when(iterationManager.canIterate(issue)).thenReturn(true, false);
+
+        when(claudeCode.executeTask(anyString(), any(Path.class), anyString(), any()))
+                .thenReturn(successResult());
+
+        // Assessment passes
+        ClaudeCodeResult assessResult = new ClaudeCodeResult();
+        assessResult.setSuccess(true);
+        assessResult.setOutput("{\"passed\": true, \"summary\": \"Looks good\", \"issues\": []}");
+        assessResult.setInputTokens(500);
+        assessResult.setOutputTokens(200);
+        assessResult.setDurationMs(2000);
+        when(claudeCode.executeTask(anyString(), any(Path.class), eq("Read,Bash(git diff:*)"), any()))
+                .thenReturn(assessResult);
+
+        // CI fails
+        when(gitHubApi.waitForChecks(eq("owner"), eq("repo"), anyString(), anyInt())).thenReturn(false);
+        when(gitHubApi.getCheckRuns("owner", "repo", "issuebot/issue-42-fix-login-bug"))
+                .thenReturn(objectMapper.createObjectNode());
+
+        workflowService.processIssue(issue);
+
+        // Max iterations reached handler called
+        verify(iterationManager).handleMaxIterationsReached(issue);
+    }
+
+    // === Test 4: Max iterations reached ===
+    @Test
+    void maxIterationsReached_escalates() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        Git mockGit = mock(Git.class);
+
+        when(gitOps.cloneOrPull("owner", "repo", "main")).thenReturn(mockGit);
+        when(gitOps.createBranch(eq(mockGit), eq(42), anyString())).thenReturn("issuebot/issue-42-fix-login-bug");
+        when(gitHubApi.getIssue("owner", "repo", 42)).thenReturn(createIssueDetails());
+        when(gitOps.repoLocalPath("owner", "repo")).thenReturn(Path.of("/tmp/repo"));
+
+        // No iterations allowed
+        when(iterationManager.canIterate(issue)).thenReturn(false);
+
+        workflowService.processIssue(issue);
+
+        verify(iterationManager).handleMaxIterationsReached(issue);
+        verify(gitHubApi, never()).createPullRequest(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean());
+    }
+
+    // === Test 5: Approval-gated mode creates draft PR ===
+    @Test
+    void approvalGatedMode_createsDraftPr() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        issue.getRepo().setMode(RepoMode.APPROVAL_GATED);
+        ObjectNode issueDetails = createIssueDetails();
+        Git mockGit = mock(Git.class);
+
+        when(gitOps.cloneOrPull("owner", "repo", "main")).thenReturn(mockGit);
+        when(gitOps.createBranch(eq(mockGit), eq(42), anyString())).thenReturn("issuebot/issue-42-fix-login-bug");
+        when(gitHubApi.getIssue("owner", "repo", 42)).thenReturn(issueDetails);
+        when(gitOps.repoLocalPath("owner", "repo")).thenReturn(Path.of("/tmp/repo"));
+        when(gitOps.openRepo("owner", "repo")).thenReturn(mockGit);
+        when(gitOps.diff(any(), anyString())).thenReturn("+ changes");
+
+        when(iterationManager.canIterate(issue)).thenReturn(true, false);
+        when(claudeCode.executeTask(anyString(), any(Path.class), anyString(), any()))
+                .thenReturn(successResult());
+
+        ClaudeCodeResult assessResult = new ClaudeCodeResult();
+        assessResult.setSuccess(true);
+        assessResult.setOutput("{\"passed\": true, \"summary\": \"All good\", \"issues\": []}");
+        assessResult.setInputTokens(500);
+        assessResult.setOutputTokens(200);
+        assessResult.setDurationMs(2000);
+        when(claudeCode.executeTask(anyString(), any(Path.class), eq("Read,Bash(git diff:*)"), any()))
+                .thenReturn(assessResult);
+
+        when(gitHubApi.waitForChecks(eq("owner"), eq("repo"), anyString(), anyInt())).thenReturn(true);
+
+        ObjectNode prNode = objectMapper.createObjectNode();
+        prNode.put("number", 101);
+        prNode.put("html_url", "https://github.com/owner/repo/pull/101");
+        when(gitHubApi.createPullRequest(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq(true)))
+                .thenReturn(prNode);
+        when(costRepository.totalCostForIssue(issue)).thenReturn(BigDecimal.valueOf(0.03));
+
+        workflowService.processIssue(issue);
+
+        assertEquals(IssueStatus.AWAITING_APPROVAL, issue.getStatus());
+        verify(gitHubApi).createPullRequest(anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), eq(true));
+    }
+
+    // === Test 6: Setup phase failure sets FAILED status ===
+    @Test
+    void setupPhaseFailure_setsFailedStatus() throws Exception {
+        TrackedIssue issue = createTestIssue();
+
+        when(gitOps.cloneOrPull("owner", "repo", "main"))
+                .thenThrow(new RuntimeException("Clone failed: repository not found"));
+
+        workflowService.processIssue(issue);
+
+        assertEquals(IssueStatus.FAILED, issue.getStatus());
+        verify(issueRepository, atLeastOnce()).save(issue);
+        verify(eventService).log(eq("PHASE_SETUP_FAILED"), anyString(), any(), eq(issue));
+    }
+
+    // === Test 7: Implementation failure continues to next iteration ===
+    @Test
+    void implementationFailure_continuesIteration() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        Git mockGit = mock(Git.class);
+
+        when(gitOps.cloneOrPull("owner", "repo", "main")).thenReturn(mockGit);
+        when(gitOps.createBranch(eq(mockGit), eq(42), anyString())).thenReturn("issuebot/issue-42-fix-login-bug");
+        when(gitHubApi.getIssue("owner", "repo", 42)).thenReturn(createIssueDetails());
+        when(gitOps.repoLocalPath("owner", "repo")).thenReturn(Path.of("/tmp/repo"));
+
+        // Allow 1 iteration
+        when(iterationManager.canIterate(issue)).thenReturn(true, false);
+
+        // Implementation throws
+        when(claudeCode.executeTask(anyString(), any(Path.class), anyString(), any()))
+                .thenThrow(new RuntimeException("Process failed"));
+
+        workflowService.processIssue(issue);
+
+        verify(iterationManager).handleMaxIterationsReached(issue);
+        verify(eventService).log(eq("PHASE_IMPL_FAILED"), anyString(), any(), eq(issue));
+    }
+
+    // === Test 8: Error in processIssueAsync is caught ===
+    @Test
+    void processIssueAsync_catchesUnhandledError() throws Exception {
+        TrackedIssue issue = createTestIssue();
+
+        // Make cloneOrPull throw an unexpected error
+        when(gitOps.cloneOrPull(anyString(), anyString(), anyString()))
+                .thenThrow(new RuntimeException("Unexpected"));
+
+        // processIssue wraps with FAILED, processIssueAsync catches the uncaught
+        workflowService.processIssueAsync(issue);
+
+        assertEquals(IssueStatus.FAILED, issue.getStatus());
+    }
+
+    // === Test 9: Cost tracking records correctly ===
+    @Test
+    void costTracking_recordsAfterImplementation() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        Git mockGit = mock(Git.class);
+
+        when(gitOps.cloneOrPull("owner", "repo", "main")).thenReturn(mockGit);
+        when(gitOps.createBranch(eq(mockGit), eq(42), anyString())).thenReturn("issuebot/issue-42-fix-login-bug");
+        when(gitHubApi.getIssue("owner", "repo", 42)).thenReturn(createIssueDetails());
+        when(gitOps.repoLocalPath("owner", "repo")).thenReturn(Path.of("/tmp/repo"));
+        when(gitOps.openRepo("owner", "repo")).thenReturn(mockGit);
+        when(gitOps.diff(any(), anyString())).thenReturn("+ code");
+
+        when(iterationManager.canIterate(issue)).thenReturn(true, false);
+
+        ClaudeCodeResult implResult = successResult();
+        implResult.setInputTokens(5000);
+        implResult.setOutputTokens(2000);
+        when(claudeCode.executeTask(anyString(), any(Path.class), anyString(), any()))
+                .thenReturn(implResult);
+
+        // Assessment fails so we exit iteration loop
+        ClaudeCodeResult failAssess = new ClaudeCodeResult();
+        failAssess.setSuccess(true);
+        failAssess.setOutput("{\"passed\": false, \"summary\": \"Incomplete\", \"issues\": []}");
+        failAssess.setInputTokens(500);
+        failAssess.setOutputTokens(100);
+        failAssess.setDurationMs(1000);
+        when(claudeCode.executeTask(anyString(), any(Path.class), eq("Read,Bash(git diff:*)"), any()))
+                .thenReturn(failAssess);
+
+        workflowService.processIssue(issue);
+
+        // Verify cost was tracked (once for implementation, once for assessment)
+        verify(costRepository, atLeast(1)).save(any(CostTracking.class));
+    }
+}


### PR DESCRIPTION
## Summary
- Added Actuator health checks for IssueBot (CLI, token, disk) and GitHub API connectivity
- Added Micrometer metrics: issue counters, token usage, Claude Code duration timers, CI wait timers, active session gauge
- Global exception handler with error page template
- Spring Security with CSRF protection and H2 console frame support
- Log sanitizer redacts GitHub tokens, Anthropic keys, and Bearer tokens from logs
- Branch name validator prevents pushes to main/master
- Cost reporting dashboard with per-repository and per-issue breakdowns (total cost, tokens, averages)
- First-run setup wizard with prerequisites check (CLI, auth, GitHub token, disk space)
- Logback configuration with rolling file appender for production logging
- 9 integration test scenarios covering happy path, self-assessment failure, CI failure, max iterations, approval-gated mode, setup failure, implementation failure, async error handling, and cost tracking
- Security unit tests for BranchNameValidator and LogSanitizer
- **52 tests, 0 failures**

Closes #20, closes #21, closes #22, closes #23, closes #24, closes #25

## Test plan
- [x] `./mvnw compile` — all 56 source files compile
- [x] `./mvnw test` — 52 tests pass, 0 failures
- [x] Health endpoints at `/actuator/health` show IssueBot and GitHub indicators
- [x] Cost report page at `/costs` shows per-repo and per-issue breakdowns
- [x] Setup wizard at `/setup` validates prerequisites
- [x] Error pages render correctly for 404/500

🤖 Generated with [Claude Code](https://claude.com/claude-code)