### PR TITLE
Fix iteration counter stuck at 1/N by refreshing entity state and reducing aggressive retry skipping

### DIFF
--- a/src/main/java/com/dbbaskette/issuebot/model/IssueStatus.java
+++ b/src/main/java/com/dbbaskette/issuebot/model/IssueStatus.java
@@ -8,5 +8,6 @@ public enum IssueStatus {
     AWAITING_APPROVAL,
     COMPLETED,
     FAILED,
-    COOLDOWN
+    COOLDOWN,
+    DECOMPOSED
 }

--- a/src/main/java/com/dbbaskette/issuebot/service/github/GitHubApiClient.java
+++ b/src/main/java/com/dbbaskette/issuebot/service/github/GitHubApiClient.java
@@ -96,6 +96,17 @@ public class GitHubApiClient {
         }
     }
 
+    public void closeIssue(String owner, String repo, int issueNumber) {
+        log.debug("Closing issue {}/{} #{}", owner, repo, issueNumber);
+        webClient.patch()
+                .uri("/repos/{owner}/{repo}/issues/{number}", owner, repo, issueNumber)
+                .bodyValue(Map.of("state", "closed", "state_reason", "completed"))
+                .retrieve()
+                .toBodilessEntity()
+                .retryWhen(retryOnServerError())
+                .block(Duration.ofSeconds(15));
+    }
+
     public JsonNode createIssue(String owner, String repo, String title, String body, List<String> labels) {
         log.debug("Creating issue in {}/{}: {}", owner, repo, title);
         Map<String, Object> payload = new HashMap<>();

--- a/src/main/java/com/dbbaskette/issuebot/service/polling/IssuePollingService.java
+++ b/src/main/java/com/dbbaskette/issuebot/service/polling/IssuePollingService.java
@@ -332,10 +332,11 @@ public class IssuePollingService {
         TrackedIssue tracked = existing.get();
         IssueStatus status = tracked.getStatus();
 
-        // Skip issues currently being processed, queued, blocked, or already completed
+        // Skip issues currently being processed, queued, blocked, completed, or decomposed
         if (status == IssueStatus.IN_PROGRESS || status == IssueStatus.QUEUED
                 || status == IssueStatus.AWAITING_APPROVAL || status == IssueStatus.COMPLETED
-                || status == IssueStatus.BLOCKED || status == IssueStatus.PENDING) {
+                || status == IssueStatus.BLOCKED || status == IssueStatus.PENDING
+                || status == IssueStatus.DECOMPOSED) {
             return false;
         }
 

--- a/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueDecompositionService.java
+++ b/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueDecompositionService.java
@@ -18,12 +18,14 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Decomposes large issues into smaller sub-issues when the implementation
  * times out or is too complex for a single pass.
+ *
+ * Also provides pre-screening: before attempting implementation, Sonnet can
+ * rate an issue's complexity and, if it's too large, decompose it upfront
+ * with implementation hints — saving expensive Opus tokens.
  *
  * Uses Claude (Sonnet) to analyze the original issue and suggest a breakdown,
  * then creates the sub-issues on GitHub and closes the original.
@@ -154,6 +156,32 @@ public class IssueDecompositionService {
     }
 
     /**
+     * Pre-screen an issue before implementation to determine if it's too large.
+     * Uses Sonnet to quickly analyze the issue against the codebase and rate complexity.
+     *
+     * @param issueDetails the GitHub issue JSON
+     * @param repoPath     the local repo checkout path
+     * @return a PreScreenResult with the verdict and optional reason
+     */
+    public PreScreenResult preScreen(JsonNode issueDetails, Path repoPath) {
+        String prompt = buildPreScreenPrompt(issueDetails);
+
+        try {
+            ClaudeCodeResult result = claudeCode.executeReview(prompt, repoPath, null);
+
+            if (result == null || result.getOutput() == null || result.getOutput().isBlank()) {
+                log.warn("Pre-screen returned empty response, allowing implementation");
+                return new PreScreenResult(false, null);
+            }
+
+            return parsePreScreenResult(result.getOutput());
+        } catch (Exception e) {
+            log.warn("Pre-screen analysis failed, allowing implementation: {}", e.getMessage());
+            return new PreScreenResult(false, null);
+        }
+    }
+
+    /**
      * Use Claude (Sonnet) to analyze the issue and produce a decomposition.
      */
     List<SubIssue> analyzeAndDecompose(JsonNode issueDetails, Path repoPath) {
@@ -168,6 +196,57 @@ public class IssueDecompositionService {
         return parseSubIssues(result.getOutput());
     }
 
+    String buildPreScreenPrompt(JsonNode issueDetails) {
+        String title = issueDetails.path("title").asText();
+        String body = issueDetails.path("body").asText("No description");
+
+        return """
+                You are a complexity estimator for an automated coding agent (IssueBot).
+                Analyze the following GitHub issue and the codebase to determine if this issue
+                is too large to implement in a single automated session (~10 minutes, ~30 tool calls).
+
+                ## Issue
+                **Title:** %s
+                **Description:**
+                %s
+
+                ## Analysis Instructions
+                1. Read the codebase structure to understand the scope
+                2. Estimate how many files need to change
+                3. Consider: new features spanning multiple layers (model, service, controller, UI)
+                   are often too large; bug fixes in 1-3 files are usually fine
+                4. If the issue mentions multiple distinct features or steps, it's likely too large
+
+                ## Output Format
+                Respond with ONLY a JSON object:
+                ```json
+                {
+                  "too_large": true or false,
+                  "reason": "brief explanation of why",
+                  "estimated_files": number of files that would need changes,
+                  "estimated_complexity": "low", "medium", or "high"
+                }
+                ```
+                """.formatted(title, body);
+    }
+
+    PreScreenResult parsePreScreenResult(String output) {
+        String json = extractJsonObject(output);
+        if (json == null) {
+            return new PreScreenResult(false, null);
+        }
+
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            boolean tooLarge = node.path("too_large").asBoolean(false);
+            String reason = node.path("reason").asText(null);
+            return new PreScreenResult(tooLarge, reason);
+        } catch (Exception e) {
+            log.warn("Failed to parse pre-screen JSON: {}", e.getMessage());
+            return new PreScreenResult(false, null);
+        }
+    }
+
     String buildDecompositionPrompt(JsonNode issueDetails) {
         String title = issueDetails.path("title").asText();
         String body = issueDetails.path("body").asText("No description");
@@ -175,6 +254,7 @@ public class IssueDecompositionService {
         return """
                 You are analyzing a GitHub issue that is too large or complex to implement in a single pass.
                 Your task is to break it down into smaller, independently implementable sub-issues.
+                For each sub-issue, provide implementation hints based on the actual codebase.
 
                 ## Original Issue
                 **Title:** %s
@@ -182,16 +262,20 @@ public class IssueDecompositionService {
                 %s
 
                 ## Instructions
-                1. Analyze the issue and identify distinct, independently implementable sub-tasks
-                2. Each sub-task should be small enough to implement in a single Claude Code session
-                3. Sub-tasks should be ordered by dependency (implement prerequisite tasks first)
-                4. Create between %d and %d sub-tasks
+                1. Read the codebase to understand the architecture and relevant files
+                2. Identify distinct, independently implementable sub-tasks
+                3. Each sub-task should be small enough to implement in a single Claude Code session
+                4. Sub-tasks should be ordered by dependency (implement prerequisite tasks first)
+                5. Create between %d and %d sub-tasks
+                6. For each sub-task, provide concrete implementation hints from the codebase
 
                 ## Output Format
                 Respond with ONLY a JSON array. No other text before or after. Each element must have:
                 - "title": a concise issue title (prefix with the step number, e.g., "1/3: ...")
                 - "description": a detailed description of what to implement
                 - "acceptance_criteria": a bullet list of what "done" looks like
+                - "hints": implementation guidance including relevant file paths, patterns to follow,
+                  and specific classes/methods to modify or use as reference
 
                 Example:
                 ```json
@@ -199,7 +283,8 @@ public class IssueDecompositionService {
                   {
                     "title": "1/3: Add data model for feature X",
                     "description": "Create the JPA entity and repository...",
-                    "acceptance_criteria": "- Entity class created\\n- Repository interface created\\n- Migration added"
+                    "acceptance_criteria": "- Entity created\\n- Repository created\\n- Migration added",
+                    "hints": "- Follow the pattern in TrackedIssue.java for the entity\\n- Add repository like TrackedIssueRepository.java\\n- Add migration as V8__add_feature_x.sql"
                   }
                 ]
                 ```
@@ -230,9 +315,10 @@ public class IssueDecompositionService {
                 String title = item.path("title").asText("").trim();
                 String description = item.path("description").asText("").trim();
                 String criteria = item.path("acceptance_criteria").asText("").trim();
+                String hints = item.path("hints").asText("").trim();
 
                 if (!title.isEmpty() && !description.isEmpty()) {
-                    result.add(new SubIssue(title, description, criteria));
+                    result.add(new SubIssue(title, description, criteria, hints));
                 }
             }
         } catch (Exception e) {
@@ -266,6 +352,25 @@ public class IssueDecompositionService {
         return null;
     }
 
+    private String extractJsonObject(String text) {
+        // Find the first { ... } block
+        int start = text.indexOf('{');
+        if (start < 0) return null;
+
+        int depth = 0;
+        for (int i = start; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '{') depth++;
+            else if (c == '}') {
+                depth--;
+                if (depth == 0) {
+                    return text.substring(start, i + 1);
+                }
+            }
+        }
+        return null;
+    }
+
     private String buildSubIssueBody(SubIssue sub, int parentIssueNumber) {
         StringBuilder body = new StringBuilder();
         body.append("_This sub-issue was automatically created by IssueBot from #")
@@ -273,6 +378,9 @@ public class IssueDecompositionService {
         body.append("## Description\n").append(sub.description()).append("\n\n");
         if (sub.acceptanceCriteria() != null && !sub.acceptanceCriteria().isBlank()) {
             body.append("## Acceptance Criteria\n").append(sub.acceptanceCriteria()).append("\n\n");
+        }
+        if (sub.hints() != null && !sub.hints().isBlank()) {
+            body.append("## Implementation Hints\n").append(sub.hints()).append("\n\n");
         }
         body.append("---\n*Auto-created by [IssueBot](https://github.com/dbbaskette/IssueBot) ")
             .append("— decomposed from #").append(parentIssueNumber).append("*");
@@ -318,5 +426,7 @@ public class IssueDecompositionService {
                 || skipReason.contains("too large");
     }
 
-    record SubIssue(String title, String description, String acceptanceCriteria) {}
+    record SubIssue(String title, String description, String acceptanceCriteria, String hints) {}
+
+    record PreScreenResult(boolean tooLarge, String reason) {}
 }

--- a/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueDecompositionService.java
+++ b/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueDecompositionService.java
@@ -1,0 +1,322 @@
+package com.dbbaskette.issuebot.service.workflow;
+
+import com.dbbaskette.issuebot.model.IssueStatus;
+import com.dbbaskette.issuebot.model.TrackedIssue;
+import com.dbbaskette.issuebot.model.WatchedRepo;
+import com.dbbaskette.issuebot.repository.TrackedIssueRepository;
+import com.dbbaskette.issuebot.service.claude.ClaudeCodeResult;
+import com.dbbaskette.issuebot.service.claude.ClaudeCodeService;
+import com.dbbaskette.issuebot.service.event.EventService;
+import com.dbbaskette.issuebot.service.github.GitHubApiClient;
+import com.dbbaskette.issuebot.service.notification.NotificationService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Decomposes large issues into smaller sub-issues when the implementation
+ * times out or is too complex for a single pass.
+ *
+ * Uses Claude (Sonnet) to analyze the original issue and suggest a breakdown,
+ * then creates the sub-issues on GitHub and closes the original.
+ */
+@Service
+public class IssueDecompositionService {
+
+    private static final Logger log = LoggerFactory.getLogger(IssueDecompositionService.class);
+    private static final int MAX_SUB_ISSUES = 5;
+    private static final int MIN_SUB_ISSUES = 2;
+
+    private final ClaudeCodeService claudeCode;
+    private final GitHubApiClient gitHubApi;
+    private final TrackedIssueRepository issueRepository;
+    private final EventService eventService;
+    private final NotificationService notificationService;
+    private final ObjectMapper objectMapper;
+
+    public IssueDecompositionService(ClaudeCodeService claudeCode,
+                                      GitHubApiClient gitHubApi,
+                                      TrackedIssueRepository issueRepository,
+                                      EventService eventService,
+                                      NotificationService notificationService,
+                                      ObjectMapper objectMapper) {
+        this.claudeCode = claudeCode;
+        this.gitHubApi = gitHubApi;
+        this.issueRepository = issueRepository;
+        this.eventService = eventService;
+        this.notificationService = notificationService;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Attempt to decompose a large issue into smaller sub-issues.
+     *
+     * @param trackedIssue the issue that timed out or was too complex
+     * @param issueDetails the GitHub issue JSON (title, body, labels)
+     * @param repoPath     the local repo checkout path (for Claude context)
+     * @param skipReason   why the retry was skipped (for context in the comment)
+     * @return true if decomposition succeeded and sub-issues were created
+     */
+    public boolean decompose(TrackedIssue trackedIssue, JsonNode issueDetails,
+                              Path repoPath, String skipReason) {
+        WatchedRepo repo = trackedIssue.getRepo();
+        int issueNumber = trackedIssue.getIssueNumber();
+
+        log.info("Attempting to decompose {} #{} into sub-issues", repo.fullName(), issueNumber);
+        eventService.log("DECOMPOSITION_STARTED",
+                "Attempting to decompose issue into sub-tasks", repo, trackedIssue);
+
+        // Ask Claude to analyze and suggest decomposition
+        List<SubIssue> subIssues;
+        try {
+            subIssues = analyzeAndDecompose(issueDetails, repoPath);
+        } catch (Exception e) {
+            log.warn("Decomposition analysis failed for {} #{}: {}",
+                    repo.fullName(), issueNumber, e.getMessage());
+            eventService.log("DECOMPOSITION_FAILED",
+                    "Analysis failed: " + e.getMessage(), repo, trackedIssue);
+            return false;
+        }
+
+        if (subIssues.size() < MIN_SUB_ISSUES) {
+            log.info("Decomposition produced fewer than {} sub-issues for {} #{}, skipping",
+                    MIN_SUB_ISSUES, repo.fullName(), issueNumber);
+            eventService.log("DECOMPOSITION_SKIPPED",
+                    "Analysis produced only " + subIssues.size() + " sub-tasks — not enough to decompose",
+                    repo, trackedIssue);
+            return false;
+        }
+
+        // Create sub-issues on GitHub
+        List<Integer> createdNumbers = new ArrayList<>();
+        for (SubIssue sub : subIssues) {
+            try {
+                String body = buildSubIssueBody(sub, issueNumber);
+                JsonNode created = gitHubApi.createIssue(
+                        repo.getOwner(), repo.getName(), sub.title(), body,
+                        List.of("agent-ready", "issuebot-decomposed"));
+                int subNumber = created.path("number").asInt();
+                createdNumbers.add(subNumber);
+                log.info("Created sub-issue #{}: {}", subNumber, sub.title());
+            } catch (Exception e) {
+                log.warn("Failed to create sub-issue '{}': {}", sub.title(), e.getMessage());
+            }
+        }
+
+        if (createdNumbers.isEmpty()) {
+            log.warn("No sub-issues could be created for {} #{}", repo.fullName(), issueNumber);
+            eventService.log("DECOMPOSITION_FAILED",
+                    "All sub-issue creations failed", repo, trackedIssue);
+            return false;
+        }
+
+        // Post comment on original issue linking sub-issues
+        String comment = buildDecompositionComment(trackedIssue, createdNumbers, skipReason);
+        try {
+            gitHubApi.addComment(repo.getOwner(), repo.getName(), issueNumber, comment);
+        } catch (Exception e) {
+            log.warn("Failed to post decomposition comment to {} #{}: {}",
+                    repo.fullName(), issueNumber, e.getMessage());
+        }
+
+        // Close original issue
+        try {
+            gitHubApi.closeIssue(repo.getOwner(), repo.getName(), issueNumber);
+        } catch (Exception e) {
+            log.warn("Failed to close original issue {} #{}: {}",
+                    repo.fullName(), issueNumber, e.getMessage());
+        }
+
+        // Mark tracked issue as DECOMPOSED
+        trackedIssue.setStatus(IssueStatus.DECOMPOSED);
+        trackedIssue.setCurrentPhase(null);
+        issueRepository.save(trackedIssue);
+
+        eventService.log("DECOMPOSITION_COMPLETED",
+                "Decomposed into " + createdNumbers.size() + " sub-issues: " + createdNumbers,
+                repo, trackedIssue);
+
+        notificationService.info("Issue Decomposed",
+                repo.fullName() + " #" + issueNumber + " split into "
+                        + createdNumbers.size() + " sub-issues");
+
+        log.info("Successfully decomposed {} #{} into {} sub-issues: {}",
+                repo.fullName(), issueNumber, createdNumbers.size(), createdNumbers);
+        return true;
+    }
+
+    /**
+     * Use Claude (Sonnet) to analyze the issue and produce a decomposition.
+     */
+    List<SubIssue> analyzeAndDecompose(JsonNode issueDetails, Path repoPath) {
+        String prompt = buildDecompositionPrompt(issueDetails);
+
+        ClaudeCodeResult result = claudeCode.executeReview(prompt, repoPath, null);
+
+        if (result == null || result.getOutput() == null || result.getOutput().isBlank()) {
+            throw new RuntimeException("Claude returned empty response for decomposition");
+        }
+
+        return parseSubIssues(result.getOutput());
+    }
+
+    String buildDecompositionPrompt(JsonNode issueDetails) {
+        String title = issueDetails.path("title").asText();
+        String body = issueDetails.path("body").asText("No description");
+
+        return """
+                You are analyzing a GitHub issue that is too large or complex to implement in a single pass.
+                Your task is to break it down into smaller, independently implementable sub-issues.
+
+                ## Original Issue
+                **Title:** %s
+                **Description:**
+                %s
+
+                ## Instructions
+                1. Analyze the issue and identify distinct, independently implementable sub-tasks
+                2. Each sub-task should be small enough to implement in a single Claude Code session
+                3. Sub-tasks should be ordered by dependency (implement prerequisite tasks first)
+                4. Create between %d and %d sub-tasks
+
+                ## Output Format
+                Respond with ONLY a JSON array. No other text before or after. Each element must have:
+                - "title": a concise issue title (prefix with the step number, e.g., "1/3: ...")
+                - "description": a detailed description of what to implement
+                - "acceptance_criteria": a bullet list of what "done" looks like
+
+                Example:
+                ```json
+                [
+                  {
+                    "title": "1/3: Add data model for feature X",
+                    "description": "Create the JPA entity and repository...",
+                    "acceptance_criteria": "- Entity class created\\n- Repository interface created\\n- Migration added"
+                  }
+                ]
+                ```
+                """.formatted(title, body, MIN_SUB_ISSUES, MAX_SUB_ISSUES);
+    }
+
+    /**
+     * Parse Claude's response into a list of sub-issues.
+     * Tries JSON parsing first, falls back to regex extraction.
+     */
+    List<SubIssue> parseSubIssues(String output) {
+        List<SubIssue> result = new ArrayList<>();
+
+        // Try to extract JSON array from the output
+        String json = extractJsonArray(output);
+        if (json == null) {
+            log.warn("Could not extract JSON array from decomposition output");
+            throw new RuntimeException("No JSON array found in decomposition response");
+        }
+
+        try {
+            JsonNode array = objectMapper.readTree(json);
+            if (!array.isArray()) {
+                throw new RuntimeException("Decomposition response is not a JSON array");
+            }
+
+            for (JsonNode item : array) {
+                String title = item.path("title").asText("").trim();
+                String description = item.path("description").asText("").trim();
+                String criteria = item.path("acceptance_criteria").asText("").trim();
+
+                if (!title.isEmpty() && !description.isEmpty()) {
+                    result.add(new SubIssue(title, description, criteria));
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse decomposition JSON: " + e.getMessage(), e);
+        }
+
+        // Cap at MAX_SUB_ISSUES
+        if (result.size() > MAX_SUB_ISSUES) {
+            result = new ArrayList<>(result.subList(0, MAX_SUB_ISSUES));
+        }
+
+        return result;
+    }
+
+    private String extractJsonArray(String text) {
+        // Find the first [ ... ] block
+        int start = text.indexOf('[');
+        if (start < 0) return null;
+
+        int depth = 0;
+        for (int i = start; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '[') depth++;
+            else if (c == ']') {
+                depth--;
+                if (depth == 0) {
+                    return text.substring(start, i + 1);
+                }
+            }
+        }
+        return null;
+    }
+
+    private String buildSubIssueBody(SubIssue sub, int parentIssueNumber) {
+        StringBuilder body = new StringBuilder();
+        body.append("_This sub-issue was automatically created by IssueBot from #")
+            .append(parentIssueNumber).append("._\n\n");
+        body.append("## Description\n").append(sub.description()).append("\n\n");
+        if (sub.acceptanceCriteria() != null && !sub.acceptanceCriteria().isBlank()) {
+            body.append("## Acceptance Criteria\n").append(sub.acceptanceCriteria()).append("\n\n");
+        }
+        body.append("---\n*Auto-created by [IssueBot](https://github.com/dbbaskette/IssueBot) ")
+            .append("— decomposed from #").append(parentIssueNumber).append("*");
+        return body.toString();
+    }
+
+    private String buildDecompositionComment(TrackedIssue trackedIssue,
+                                               List<Integer> subIssueNumbers,
+                                               String skipReason) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("## IssueBot: Issue Decomposed\n\n");
+        sb.append("This issue was too large to resolve in a single pass");
+        if (skipReason != null) {
+            sb.append(":\n> ").append(skipReason);
+        }
+        sb.append("\n\n");
+        sb.append("IssueBot has automatically split this into **")
+          .append(subIssueNumbers.size()).append("** smaller sub-issues:\n\n");
+
+        for (int num : subIssueNumbers) {
+            sb.append("- #").append(num).append("\n");
+        }
+
+        sb.append("\nThis issue will be closed. Progress will continue on the sub-issues above.\n\n");
+
+        if (trackedIssue.getBranchName() != null) {
+            sb.append("Any partial progress is available on branch `")
+              .append(trackedIssue.getBranchName()).append("`.\n\n");
+        }
+
+        sb.append("---\n*Generated by [IssueBot](https://github.com/dbbaskette/IssueBot)*");
+        return sb.toString();
+    }
+
+    /**
+     * Check whether a skip reason indicates a timeout or complexity issue
+     * that warrants decomposition.
+     */
+    public boolean isDecomposable(String skipReason) {
+        if (skipReason == null) return false;
+        return skipReason.contains("timed out")
+                || skipReason.contains("too complex")
+                || skipReason.contains("too large");
+    }
+
+    record SubIssue(String title, String description, String acceptanceCriteria) {}
+}

--- a/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueWorkflowService.java
+++ b/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueWorkflowService.java
@@ -156,15 +156,22 @@ public class IssueWorkflowService {
         int prNumber = 0;
 
         while (iterationManager.canIterate(trackedIssue)) {
+            // Re-read entity from DB to pick up any external changes (e.g., maxIterations edits)
+            trackedIssue = issueRepository.findById(trackedIssue.getId()).orElse(trackedIssue);
+            repo = trackedIssue.getRepo();
+
             int iterationNum = trackedIssue.getCurrentIteration() + 1;
+            int maxIterations = repo.getMaxIterations();
             trackedIssue.setCurrentIteration(iterationNum);
             issueRepository.save(trackedIssue);
 
             Iteration iteration = new Iteration(trackedIssue, iterationNum);
             iterationRepository.save(iteration);
 
+            log.info("Iteration counter updated: {}/{} for {} #{}",
+                    iterationNum, maxIterations, repo.fullName(), issueNumber);
             eventService.log("ITERATION_STARTED",
-                    "Starting iteration " + iterationNum, repo, trackedIssue);
+                    "Starting iteration " + iterationNum + "/" + maxIterations, repo, trackedIssue);
 
             // === Phase 2: Implementation (Opus) ===
             ClaudeCodeResult implResult;

--- a/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueWorkflowService.java
+++ b/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueWorkflowService.java
@@ -54,6 +54,7 @@ public class IssueWorkflowService {
     private final SseService sseService;
     private final NotificationService notificationService;
     private final IterationManager iterationManager;
+    private final IssueDecompositionService decompositionService;
     private final ObjectMapper objectMapper;
 
     public IssueWorkflowService(GitOperationsService gitOps,
@@ -68,6 +69,7 @@ public class IssueWorkflowService {
                                  SseService sseService,
                                  NotificationService notificationService,
                                  IterationManager iterationManager,
+                                 IssueDecompositionService decompositionService,
                                  ObjectMapper objectMapper) {
         this.gitOps = gitOps;
         this.gitHubApi = gitHubApi;
@@ -81,6 +83,7 @@ public class IssueWorkflowService {
         this.sseService = sseService;
         this.notificationService = notificationService;
         this.iterationManager = iterationManager;
+        this.decompositionService = decompositionService;
         this.objectMapper = objectMapper;
     }
 
@@ -203,6 +206,12 @@ public class IssueWorkflowService {
                 if (skipReason != null) {
                     log.warn("Skipping retry for {} #{}: {}", repo.fullName(),
                             trackedIssue.getIssueNumber(), skipReason);
+                    // Attempt decomposition for timeout/complexity issues
+                    if (decompositionService.isDecomposable(skipReason)
+                            && decompositionService.decompose(trackedIssue, issueDetails,
+                                    repoPath, skipReason)) {
+                        return;
+                    }
                     iterationManager.handleRetrySkipped(trackedIssue, skipReason);
                     return;
                 }
@@ -262,6 +271,11 @@ public class IssueWorkflowService {
                 if (skipReason != null) {
                     log.warn("Skipping retry for {} #{}: {}", repo.fullName(),
                             trackedIssue.getIssueNumber(), skipReason);
+                    if (decompositionService.isDecomposable(skipReason)
+                            && decompositionService.decompose(trackedIssue, issueDetails,
+                                    repoPath, skipReason)) {
+                        return;
+                    }
                     iterationManager.handleRetrySkipped(trackedIssue, skipReason);
                     return;
                 }
@@ -347,7 +361,14 @@ public class IssueWorkflowService {
             }
         }
 
-        // Max iterations reached
+        // Max iterations reached — attempt decomposition before escalating
+        String maxIterReason = "Failed after " + repo.getMaxIterations()
+                + " iterations — task is likely too large for automated resolution";
+        if (decompositionService.isDecomposable(maxIterReason)
+                && decompositionService.decompose(trackedIssue, issueDetails,
+                        repoPath, maxIterReason)) {
+            return;
+        }
         iterationManager.handleMaxIterationsReached(trackedIssue);
     }
 

--- a/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueWorkflowService.java
+++ b/src/main/java/com/dbbaskette/issuebot/service/workflow/IssueWorkflowService.java
@@ -148,6 +148,26 @@ public class IssueWorkflowService {
             return;
         }
 
+        // === Pre-Screen: Check if issue is too large before burning Opus tokens ===
+        try {
+            IssueDecompositionService.PreScreenResult screenResult =
+                    decompositionService.preScreen(issueDetails, repoPath);
+            if (screenResult.tooLarge()) {
+                log.info("Pre-screen flagged {} #{} as too large: {}",
+                        repo.fullName(), issueNumber, screenResult.reason());
+                eventService.log("PRE_SCREEN_TOO_LARGE",
+                        "Pre-screen: " + screenResult.reason(), repo, trackedIssue);
+                if (decompositionService.decompose(trackedIssue, issueDetails,
+                        repoPath, "Pre-screen: " + screenResult.reason())) {
+                    return;
+                }
+                log.info("Decomposition failed after pre-screen, proceeding with implementation");
+            }
+        } catch (Exception e) {
+            log.warn("Pre-screen check failed for {} #{}, proceeding: {}",
+                    repo.fullName(), issueNumber, e.getMessage());
+        }
+
         log.info("Entering iteration loop for {} #{}, maxIterations={}",
                 repo.fullName(), issueNumber, repo.getMaxIterations());
 

--- a/src/main/java/com/dbbaskette/issuebot/service/workflow/IterationManager.java
+++ b/src/main/java/com/dbbaskette/issuebot/service/workflow/IterationManager.java
@@ -6,6 +6,7 @@ import com.dbbaskette.issuebot.model.TrackedIssue;
 import com.dbbaskette.issuebot.model.WatchedRepo;
 import com.dbbaskette.issuebot.repository.IterationRepository;
 import com.dbbaskette.issuebot.repository.TrackedIssueRepository;
+import com.dbbaskette.issuebot.repository.WatchedRepoRepository;
 import com.dbbaskette.issuebot.service.claude.ClaudeCodeResult;
 import com.dbbaskette.issuebot.service.event.EventService;
 import com.dbbaskette.issuebot.service.github.GitHubApiClient;
@@ -31,17 +32,20 @@ public class IterationManager {
     private static final int DEFAULT_COOLDOWN_HOURS = 24;
 
     private final TrackedIssueRepository issueRepository;
+    private final WatchedRepoRepository repoRepository;
     private final IterationRepository iterationRepository;
     private final GitHubApiClient gitHubApi;
     private final EventService eventService;
     private final NotificationService notificationService;
 
     public IterationManager(TrackedIssueRepository issueRepository,
+                             WatchedRepoRepository repoRepository,
                              IterationRepository iterationRepository,
                              GitHubApiClient gitHubApi,
                              EventService eventService,
                              NotificationService notificationService) {
         this.issueRepository = issueRepository;
+        this.repoRepository = repoRepository;
         this.iterationRepository = iterationRepository;
         this.gitHubApi = gitHubApi;
         this.eventService = eventService;
@@ -50,10 +54,25 @@ public class IterationManager {
 
     /**
      * Check if the issue can undergo another iteration.
+     * Re-reads maxIterations from the database to pick up any settings changes
+     * made while the workflow is running.
      */
     public boolean canIterate(TrackedIssue trackedIssue) {
-        int maxIterations = trackedIssue.getRepo().getMaxIterations();
-        return trackedIssue.getCurrentIteration() < maxIterations;
+        int maxIterations = getMaxIterationsFromDb(trackedIssue);
+        int current = trackedIssue.getCurrentIteration();
+        log.debug("canIterate check: currentIteration={}, maxIterations={}", current, maxIterations);
+        return current < maxIterations;
+    }
+
+    /**
+     * Read the current maxIterations value from the database, falling back
+     * to the in-memory value if the repo is not found.
+     */
+    private int getMaxIterationsFromDb(TrackedIssue trackedIssue) {
+        WatchedRepo repo = trackedIssue.getRepo();
+        return repoRepository.findById(repo.getId())
+                .map(WatchedRepo::getMaxIterations)
+                .orElse(repo.getMaxIterations());
     }
 
     /**
@@ -62,14 +81,19 @@ public class IterationManager {
      */
     public String shouldSkipRetry(TrackedIssue trackedIssue, ClaudeCodeResult implResult,
                                     String ciResult, String failureContext) {
+        int currentIter = trackedIssue.getCurrentIteration();
+
         // Timed out — task is too large for a single session, retrying will burn the same tokens
-        if (implResult != null && implResult.isTimedOut()) {
-            return "Implementation timed out — task is likely too large for automated resolution";
+        // Only skip after at least 2 attempts so the first timeout still allows one retry
+        if (implResult != null && implResult.isTimedOut() && currentIter > 1) {
+            return "Implementation timed out on iteration " + currentIter
+                    + " — task is likely too large for automated resolution";
         }
 
         // Excessive token usage without success — task is at the boundary of what can be done
         // Opus at ~200K+ output tokens means it wrote extensively and still failed
-        if (implResult != null && implResult.getOutputTokens() > 150_000) {
+        // Only skip after at least 2 attempts
+        if (implResult != null && implResult.getOutputTokens() > 150_000 && currentIter > 1) {
             return "Implementation consumed " + implResult.getOutputTokens()
                     + " output tokens without success — task is too complex for retry";
         }
@@ -77,15 +101,18 @@ public class IterationManager {
         // Implementation returned failure with no files changed — Claude couldn't make progress
         if (implResult != null && !implResult.isSuccess()
                 && implResult.getFilesChanged().isEmpty()
-                && trackedIssue.getCurrentIteration() > 1) {
-            return "Implementation made no progress (0 files changed) across multiple iterations";
+                && currentIter > 1) {
+            return "Implementation made no progress (0 files changed) across " + currentIter + " iterations";
         }
 
-        // Check for repeated implementation failures (same error both iterations)
-        if (implResult != null && !implResult.isSuccess() && failureContext != null
-                && trackedIssue.getCurrentIteration() > 1) {
-            return "Implementation failed again on iteration " + trackedIssue.getCurrentIteration()
-                    + " — unlikely to succeed on retry";
+        // Check for repeated implementation failures: only skip if the previous context
+        // was itself an implementation failure (not review feedback or human instructions)
+        if (implResult != null && !implResult.isSuccess()
+                && failureContext != null
+                && failureContext.startsWith("Claude Code failed:")
+                && currentIter > 1) {
+            return "Implementation failed again on iteration " + currentIter
+                    + " with same error type — unlikely to succeed on retry";
         }
 
         return null; // OK to retry
@@ -130,9 +157,13 @@ public class IterationManager {
     /**
      * Check if the issue can undergo another review iteration.
      * Uses maxReviewIterations from WatchedRepo (default 2).
+     * Re-reads from DB to pick up settings changes.
      */
     public boolean canReviewIterate(TrackedIssue trackedIssue) {
-        int maxReviewIterations = trackedIssue.getRepo().getMaxReviewIterations();
+        WatchedRepo repo = trackedIssue.getRepo();
+        int maxReviewIterations = repoRepository.findById(repo.getId())
+                .map(WatchedRepo::getMaxReviewIterations)
+                .orElse(repo.getMaxReviewIterations());
         return trackedIssue.getCurrentReviewIteration() < maxReviewIterations;
     }
 

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -451,6 +451,12 @@ main::before {
     border-color: rgba(139,92,246,0.25);
 }
 
+.status-decomposed {
+    background: rgba(56,189,248,0.12);
+    color: #38bdf8;
+    border-color: rgba(56,189,248,0.25);
+}
+
 /* ============================================================
    Data Tables — Operations Log
    ============================================================ */

--- a/src/test/java/com/dbbaskette/issuebot/service/polling/IssuePollingServiceTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/service/polling/IssuePollingServiceTest.java
@@ -119,4 +119,14 @@ class IssuePollingServiceTest {
         assertEquals(IssueStatus.FAILED, tracked.getStatus());
         assertEquals(3, tracked.getCurrentIteration());
     }
+
+    @Test
+    void qualifiesForProcessing_decomposedIssue() {
+        TrackedIssue tracked = new TrackedIssue(testRepo, 1, "Test");
+        tracked.setStatus(IssueStatus.DECOMPOSED);
+        when(issueRepository.findByRepoAndIssueNumber(testRepo, 1)).thenReturn(Optional.of(tracked));
+
+        // DECOMPOSED issues are terminal — sub-issues handle the work
+        assertFalse(pollingService.qualifiesForProcessing(testRepo, 1));
+    }
 }

--- a/src/test/java/com/dbbaskette/issuebot/service/workflow/IntegrationWorkflowTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/service/workflow/IntegrationWorkflowTest.java
@@ -131,6 +131,8 @@ class IntegrationWorkflowTest {
         when(costRepository.totalCostForIssue(issue)).thenReturn(BigDecimal.valueOf(0.05));
         when(costRepository.totalCostForIssueByPhase(eq(issue), eq("IMPLEMENTATION"))).thenReturn(BigDecimal.valueOf(0.04));
         when(costRepository.totalCostForIssueByPhase(eq(issue), eq("REVIEW"))).thenReturn(BigDecimal.valueOf(0.01));
+        // Iteration loop re-reads entity from DB — return the same in-memory issue
+        when(issueRepository.findById(issue.getId())).thenReturn(java.util.Optional.of(issue));
     }
 
     // === Test 1: Happy path — implementation, CI, PR, review pass, completion ===

--- a/src/test/java/com/dbbaskette/issuebot/service/workflow/IntegrationWorkflowTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/service/workflow/IntegrationWorkflowTest.java
@@ -47,6 +47,7 @@ class IntegrationWorkflowTest {
     private SseService sseService;
     private NotificationService notificationService;
     private IterationManager iterationManager;
+    private IssueDecompositionService decompositionService;
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -63,13 +64,14 @@ class IntegrationWorkflowTest {
         sseService = mock(SseService.class);
         notificationService = mock(NotificationService.class);
         iterationManager = mock(IterationManager.class);
+        decompositionService = mock(IssueDecompositionService.class);
         objectMapper = new ObjectMapper();
 
         workflowService = new IssueWorkflowService(
                 gitOps, gitHubApi, claudeCode, codeReviewService, ciTemplateService,
                 issueRepository, iterationRepository, costRepository,
                 eventService, sseService, notificationService, iterationManager,
-                objectMapper);
+                decompositionService, objectMapper);
     }
 
     private TrackedIssue createTestIssue() {

--- a/src/test/java/com/dbbaskette/issuebot/service/workflow/IntegrationWorkflowTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/service/workflow/IntegrationWorkflowTest.java
@@ -135,6 +135,9 @@ class IntegrationWorkflowTest {
         when(costRepository.totalCostForIssueByPhase(eq(issue), eq("REVIEW"))).thenReturn(BigDecimal.valueOf(0.01));
         // Iteration loop re-reads entity from DB — return the same in-memory issue
         when(issueRepository.findById(issue.getId())).thenReturn(java.util.Optional.of(issue));
+        // Default pre-screen: not too large
+        when(decompositionService.preScreen(any(), any()))
+                .thenReturn(new IssueDecompositionService.PreScreenResult(false, null));
     }
 
     // === Test 1: Happy path — implementation, CI, PR, review pass, completion ===
@@ -363,5 +366,59 @@ class IntegrationWorkflowTest {
         workflowService.processIssueAsync(issue);
 
         assertEquals(IssueStatus.FAILED, issue.getStatus());
+    }
+
+    // === Test 10: Pre-screen decomposes before implementation ===
+    @Test
+    void preScreen_tooLarge_decomposesWithoutImplementation() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        ObjectNode issueDetails = createIssueDetails();
+        setupCommonMocks(issue, issueDetails);
+
+        // Override pre-screen to flag as too large
+        when(decompositionService.preScreen(any(), any()))
+                .thenReturn(new IssueDecompositionService.PreScreenResult(true, "Spans 12+ files across 4 layers"));
+
+        // Decomposition succeeds
+        when(decompositionService.decompose(eq(issue), any(), any(), anyString())).thenReturn(true);
+
+        workflowService.processIssue(issue);
+
+        // Verify decomposition was called but implementation was NOT
+        verify(decompositionService).decompose(eq(issue), any(), any(), contains("Pre-screen"));
+        verify(claudeCode, never()).executeImplementation(anyString(), any(Path.class), any());
+        verify(iterationManager, never()).canIterate(any());
+    }
+
+    // === Test 11: Pre-screen failure falls through to implementation ===
+    @Test
+    void preScreen_failureFallsThrough() throws Exception {
+        TrackedIssue issue = createTestIssue();
+        issue.getRepo().setCiEnabled(false);
+        ObjectNode issueDetails = createIssueDetails();
+        setupCommonMocks(issue, issueDetails);
+
+        // Pre-screen flags too large but decomposition fails
+        when(decompositionService.preScreen(any(), any()))
+                .thenReturn(new IssueDecompositionService.PreScreenResult(true, "Large issue"));
+        when(decompositionService.decompose(eq(issue), any(), any(), anyString())).thenReturn(false);
+
+        when(iterationManager.canIterate(issue)).thenReturn(true, false);
+        when(claudeCode.executeImplementation(anyString(), any(Path.class), any()))
+                .thenReturn(successResult());
+
+        when(gitHubApi.listOpenPullRequests(anyString(), anyString(), anyString())).thenReturn(List.of());
+        ObjectNode prNode = objectMapper.createObjectNode();
+        prNode.put("number", 104);
+        when(gitHubApi.createPullRequest(anyString(), anyString(), anyString(), anyString(),
+                anyString(), anyString(), eq(false))).thenReturn(prNode);
+        when(codeReviewService.reviewCode(any(Path.class), anyString(), anyString(),
+                anyString(), anyBoolean(), any())).thenReturn(passedReview());
+
+        workflowService.processIssue(issue);
+
+        // Implementation still ran after decomposition failed
+        verify(claudeCode).executeImplementation(anyString(), any(Path.class), any());
+        assertEquals(IssueStatus.COMPLETED, issue.getStatus());
     }
 }

--- a/src/test/java/com/dbbaskette/issuebot/service/workflow/IssueDecompositionServiceTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/service/workflow/IssueDecompositionServiceTest.java
@@ -81,17 +81,20 @@ class IssueDecompositionServiceTest {
                   {
                     "title": "1/3: Add data model",
                     "description": "Create JPA entity and repository",
-                    "acceptance_criteria": "- Entity created\\n- Tests pass"
+                    "acceptance_criteria": "- Entity created\\n- Tests pass",
+                    "hints": "- Follow TrackedIssue.java pattern\\n- Add V8 migration"
                   },
                   {
                     "title": "2/3: Implement service layer",
                     "description": "Create service with business logic",
-                    "acceptance_criteria": "- Service created\\n- Tests pass"
+                    "acceptance_criteria": "- Service created\\n- Tests pass",
+                    "hints": "- See IssueWorkflowService for patterns"
                   },
                   {
                     "title": "3/3: Add REST endpoint",
                     "description": "Create controller with endpoints",
-                    "acceptance_criteria": "- Endpoint works\\n- Tests pass"
+                    "acceptance_criteria": "- Endpoint works\\n- Tests pass",
+                    "hints": "- Follow IssueController pattern"
                   }
                 ]
                 """;
@@ -100,6 +103,7 @@ class IssueDecompositionServiceTest {
         assertEquals(3, result.size());
         assertEquals("1/3: Add data model", result.get(0).title());
         assertEquals("Create JPA entity and repository", result.get(0).description());
+        assertTrue(result.get(0).hints().contains("TrackedIssue.java"));
     }
 
     @Test
@@ -108,14 +112,27 @@ class IssueDecompositionServiceTest {
                 Here's the decomposition:
                 ```json
                 [
-                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done"},
-                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done"}
+                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done", "hints": "Look at Foo.java"},
+                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done", "hints": ""}
                 ]
                 ```
                 """;
 
         List<IssueDecompositionService.SubIssue> result = decompositionService.parseSubIssues(output);
         assertEquals(2, result.size());
+    }
+
+    @Test
+    void parseSubIssues_missingHintsField_defaultsToEmpty() {
+        String json = """
+                [
+                  {"title": "1/2: Task", "description": "Do thing", "acceptance_criteria": "Done"},
+                  {"title": "2/2: Task2", "description": "Do other", "acceptance_criteria": "Done"}
+                ]
+                """;
+        List<IssueDecompositionService.SubIssue> result = decompositionService.parseSubIssues(json);
+        assertEquals(2, result.size());
+        assertEquals("", result.get(0).hints());
     }
 
     @Test
@@ -131,7 +148,8 @@ class IssueDecompositionServiceTest {
             if (i > 1) json.append(",");
             json.append("{\"title\":\"").append(i).append("/8: Task ").append(i)
                 .append("\",\"description\":\"Do thing ").append(i)
-                .append("\",\"acceptance_criteria\":\"Done\"}");
+                .append("\",\"acceptance_criteria\":\"Done\"")
+                .append(",\"hints\":\"Hint ").append(i).append("\"}");
         }
         json.append("]");
 
@@ -146,8 +164,8 @@ class IssueDecompositionServiceTest {
 
         String claudeOutput = """
                 [
-                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done"},
-                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done"}
+                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done", "hints": "Look at Foo.java"},
+                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done", "hints": "See Bar.java"}
                 ]
                 """;
         ClaudeCodeResult claudeResult = new ClaudeCodeResult();
@@ -219,8 +237,8 @@ class IssueDecompositionServiceTest {
 
         String claudeOutput = """
                 [
-                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done"},
-                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done"}
+                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done", "hints": ""},
+                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done", "hints": ""}
                 ]
                 """;
         ClaudeCodeResult claudeResult = new ClaudeCodeResult();
@@ -246,6 +264,104 @@ class IssueDecompositionServiceTest {
         assertTrue(prompt.contains("Fix the login bug"));
         assertTrue(prompt.contains("special characters"));
         assertTrue(prompt.contains("sub-tasks"));
+        assertTrue(prompt.contains("hints"));
+    }
+
+    // === Pre-screen tests ===
+
+    @Test
+    void preScreen_tooLarge_returnsTrue() {
+        String claudeOutput = """
+                {"too_large": true, "reason": "Spans 4 layers with 12+ files", "estimated_files": 12, "estimated_complexity": "high"}
+                """;
+        ClaudeCodeResult claudeResult = new ClaudeCodeResult();
+        claudeResult.setSuccess(true);
+        claudeResult.setOutput(claudeOutput);
+        when(claudeCode.executeReview(anyString(), any(Path.class), any())).thenReturn(claudeResult);
+
+        IssueDecompositionService.PreScreenResult result =
+                decompositionService.preScreen(createIssueDetails(), Path.of("/tmp/repo"));
+
+        assertTrue(result.tooLarge());
+        assertTrue(result.reason().contains("12+ files"));
+    }
+
+    @Test
+    void preScreen_notTooLarge_returnsFalse() {
+        String claudeOutput = """
+                {"too_large": false, "reason": "Simple bug fix in 2 files", "estimated_files": 2, "estimated_complexity": "low"}
+                """;
+        ClaudeCodeResult claudeResult = new ClaudeCodeResult();
+        claudeResult.setSuccess(true);
+        claudeResult.setOutput(claudeOutput);
+        when(claudeCode.executeReview(anyString(), any(Path.class), any())).thenReturn(claudeResult);
+
+        IssueDecompositionService.PreScreenResult result =
+                decompositionService.preScreen(createIssueDetails(), Path.of("/tmp/repo"));
+
+        assertFalse(result.tooLarge());
+    }
+
+    @Test
+    void preScreen_claudeFailure_defaultsToFalse() {
+        when(claudeCode.executeReview(anyString(), any(Path.class), any()))
+                .thenThrow(new RuntimeException("API error"));
+
+        IssueDecompositionService.PreScreenResult result =
+                decompositionService.preScreen(createIssueDetails(), Path.of("/tmp/repo"));
+
+        assertFalse(result.tooLarge());
+    }
+
+    @Test
+    void preScreen_emptyResponse_defaultsToFalse() {
+        ClaudeCodeResult claudeResult = new ClaudeCodeResult();
+        claudeResult.setOutput("");
+        when(claudeCode.executeReview(anyString(), any(Path.class), any())).thenReturn(claudeResult);
+
+        IssueDecompositionService.PreScreenResult result =
+                decompositionService.preScreen(createIssueDetails(), Path.of("/tmp/repo"));
+
+        assertFalse(result.tooLarge());
+    }
+
+    @Test
+    void preScreen_invalidJson_defaultsToFalse() {
+        ClaudeCodeResult claudeResult = new ClaudeCodeResult();
+        claudeResult.setOutput("Not JSON at all");
+        when(claudeCode.executeReview(anyString(), any(Path.class), any())).thenReturn(claudeResult);
+
+        IssueDecompositionService.PreScreenResult result =
+                decompositionService.preScreen(createIssueDetails(), Path.of("/tmp/repo"));
+
+        assertFalse(result.tooLarge());
+    }
+
+    @Test
+    void parsePreScreenResult_validJson() {
+        String output = """
+                ```json
+                {"too_large": true, "reason": "Multiple distinct features requested", "estimated_files": 8, "estimated_complexity": "high"}
+                ```
+                """;
+        IssueDecompositionService.PreScreenResult result = decompositionService.parsePreScreenResult(output);
+        assertTrue(result.tooLarge());
+        assertEquals("Multiple distinct features requested", result.reason());
+    }
+
+    @Test
+    void parsePreScreenResult_noJson_defaultsFalse() {
+        IssueDecompositionService.PreScreenResult result =
+                decompositionService.parsePreScreenResult("Just some text, no JSON.");
+        assertFalse(result.tooLarge());
+    }
+
+    @Test
+    void buildPreScreenPrompt_includesTitleAndBody() {
+        String prompt = decompositionService.buildPreScreenPrompt(createIssueDetails());
+        assertTrue(prompt.contains("Fix the login bug"));
+        assertTrue(prompt.contains("special characters"));
+        assertTrue(prompt.contains("too_large"));
     }
 
     private TrackedIssue createIssue() {

--- a/src/test/java/com/dbbaskette/issuebot/service/workflow/IssueDecompositionServiceTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/service/workflow/IssueDecompositionServiceTest.java
@@ -1,0 +1,269 @@
+package com.dbbaskette.issuebot.service.workflow;
+
+import com.dbbaskette.issuebot.model.IssueStatus;
+import com.dbbaskette.issuebot.model.TrackedIssue;
+import com.dbbaskette.issuebot.model.WatchedRepo;
+import com.dbbaskette.issuebot.repository.TrackedIssueRepository;
+import com.dbbaskette.issuebot.service.claude.ClaudeCodeResult;
+import com.dbbaskette.issuebot.service.claude.ClaudeCodeService;
+import com.dbbaskette.issuebot.service.event.EventService;
+import com.dbbaskette.issuebot.service.github.GitHubApiClient;
+import com.dbbaskette.issuebot.service.notification.NotificationService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class IssueDecompositionServiceTest {
+
+    private IssueDecompositionService decompositionService;
+    private ClaudeCodeService claudeCode;
+    private GitHubApiClient gitHubApi;
+    private TrackedIssueRepository issueRepository;
+    private EventService eventService;
+    private NotificationService notificationService;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        claudeCode = mock(ClaudeCodeService.class);
+        gitHubApi = mock(GitHubApiClient.class);
+        issueRepository = mock(TrackedIssueRepository.class);
+        eventService = mock(EventService.class);
+        notificationService = mock(NotificationService.class);
+        objectMapper = new ObjectMapper();
+
+        decompositionService = new IssueDecompositionService(
+                claudeCode, gitHubApi, issueRepository, eventService,
+                notificationService, objectMapper);
+    }
+
+    @Test
+    void isDecomposable_timeout() {
+        assertTrue(decompositionService.isDecomposable(
+                "Implementation timed out on iteration 2 — task is likely too large for automated resolution"));
+    }
+
+    @Test
+    void isDecomposable_tooComplex() {
+        assertTrue(decompositionService.isDecomposable(
+                "Implementation consumed 200000 output tokens without success — task is too complex for retry"));
+    }
+
+    @Test
+    void isDecomposable_tooLarge() {
+        assertTrue(decompositionService.isDecomposable(
+                "Failed after 5 iterations — task is likely too large for automated resolution"));
+    }
+
+    @Test
+    void isDecomposable_normalFailure() {
+        assertFalse(decompositionService.isDecomposable(
+                "Implementation failed again on iteration 2 with same error type"));
+    }
+
+    @Test
+    void isDecomposable_null() {
+        assertFalse(decompositionService.isDecomposable(null));
+    }
+
+    @Test
+    void parseSubIssues_validJson() {
+        String json = """
+                [
+                  {
+                    "title": "1/3: Add data model",
+                    "description": "Create JPA entity and repository",
+                    "acceptance_criteria": "- Entity created\\n- Tests pass"
+                  },
+                  {
+                    "title": "2/3: Implement service layer",
+                    "description": "Create service with business logic",
+                    "acceptance_criteria": "- Service created\\n- Tests pass"
+                  },
+                  {
+                    "title": "3/3: Add REST endpoint",
+                    "description": "Create controller with endpoints",
+                    "acceptance_criteria": "- Endpoint works\\n- Tests pass"
+                  }
+                ]
+                """;
+
+        List<IssueDecompositionService.SubIssue> result = decompositionService.parseSubIssues(json);
+        assertEquals(3, result.size());
+        assertEquals("1/3: Add data model", result.get(0).title());
+        assertEquals("Create JPA entity and repository", result.get(0).description());
+    }
+
+    @Test
+    void parseSubIssues_jsonInMarkdownCodeBlock() {
+        String output = """
+                Here's the decomposition:
+                ```json
+                [
+                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done"},
+                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done"}
+                ]
+                ```
+                """;
+
+        List<IssueDecompositionService.SubIssue> result = decompositionService.parseSubIssues(output);
+        assertEquals(2, result.size());
+    }
+
+    @Test
+    void parseSubIssues_noJsonArray_throws() {
+        assertThrows(RuntimeException.class, () ->
+                decompositionService.parseSubIssues("No JSON here, just text."));
+    }
+
+    @Test
+    void parseSubIssues_capsAtMaxSubIssues() {
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 1; i <= 8; i++) {
+            if (i > 1) json.append(",");
+            json.append("{\"title\":\"").append(i).append("/8: Task ").append(i)
+                .append("\",\"description\":\"Do thing ").append(i)
+                .append("\",\"acceptance_criteria\":\"Done\"}");
+        }
+        json.append("]");
+
+        List<IssueDecompositionService.SubIssue> result = decompositionService.parseSubIssues(json.toString());
+        assertEquals(5, result.size()); // capped at MAX_SUB_ISSUES
+    }
+
+    @Test
+    void decompose_success() {
+        TrackedIssue issue = createIssue();
+        ObjectNode issueDetails = createIssueDetails();
+
+        String claudeOutput = """
+                [
+                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done"},
+                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done"}
+                ]
+                """;
+        ClaudeCodeResult claudeResult = new ClaudeCodeResult();
+        claudeResult.setSuccess(true);
+        claudeResult.setOutput(claudeOutput);
+        when(claudeCode.executeReview(anyString(), any(Path.class), any())).thenReturn(claudeResult);
+
+        ObjectNode sub1 = objectMapper.createObjectNode();
+        sub1.put("number", 100);
+        ObjectNode sub2 = objectMapper.createObjectNode();
+        sub2.put("number", 101);
+        when(gitHubApi.createIssue(eq("owner"), eq("repo"), anyString(), anyString(), anyList()))
+                .thenReturn(sub1, sub2);
+
+        boolean result = decompositionService.decompose(issue, issueDetails,
+                Path.of("/tmp/repo"), "timed out");
+
+        assertTrue(result);
+        assertEquals(IssueStatus.DECOMPOSED, issue.getStatus());
+        assertNull(issue.getCurrentPhase());
+        verify(issueRepository).save(issue);
+        verify(gitHubApi, times(2)).createIssue(eq("owner"), eq("repo"), anyString(), anyString(), anyList());
+        verify(gitHubApi).addComment(eq("owner"), eq("repo"), eq(42), contains("sub-issues"));
+        verify(gitHubApi).closeIssue("owner", "repo", 42);
+        verify(notificationService).info(eq("Issue Decomposed"), anyString());
+    }
+
+    @Test
+    void decompose_analysisReturnsOneSubIssue_returnsFalse() {
+        TrackedIssue issue = createIssue();
+        ObjectNode issueDetails = createIssueDetails();
+
+        String claudeOutput = """
+                [{"title": "Only task", "description": "Single task", "acceptance_criteria": "Done"}]
+                """;
+        ClaudeCodeResult claudeResult = new ClaudeCodeResult();
+        claudeResult.setSuccess(true);
+        claudeResult.setOutput(claudeOutput);
+        when(claudeCode.executeReview(anyString(), any(Path.class), any())).thenReturn(claudeResult);
+
+        boolean result = decompositionService.decompose(issue, issueDetails,
+                Path.of("/tmp/repo"), "timed out");
+
+        assertFalse(result);
+        assertNotEquals(IssueStatus.DECOMPOSED, issue.getStatus());
+        verify(gitHubApi, never()).createIssue(anyString(), anyString(), anyString(), anyString(), anyList());
+    }
+
+    @Test
+    void decompose_claudeReturnsNull_returnsFalse() {
+        TrackedIssue issue = createIssue();
+        ObjectNode issueDetails = createIssueDetails();
+
+        ClaudeCodeResult claudeResult = new ClaudeCodeResult();
+        claudeResult.setSuccess(false);
+        claudeResult.setOutput(null);
+        when(claudeCode.executeReview(anyString(), any(Path.class), any())).thenReturn(claudeResult);
+
+        boolean result = decompositionService.decompose(issue, issueDetails,
+                Path.of("/tmp/repo"), "timed out");
+
+        assertFalse(result);
+    }
+
+    @Test
+    void decompose_allGitHubCreationsFail_returnsFalse() {
+        TrackedIssue issue = createIssue();
+        ObjectNode issueDetails = createIssueDetails();
+
+        String claudeOutput = """
+                [
+                  {"title": "1/2: First task", "description": "Do first thing", "acceptance_criteria": "Done"},
+                  {"title": "2/2: Second task", "description": "Do second thing", "acceptance_criteria": "Done"}
+                ]
+                """;
+        ClaudeCodeResult claudeResult = new ClaudeCodeResult();
+        claudeResult.setSuccess(true);
+        claudeResult.setOutput(claudeOutput);
+        when(claudeCode.executeReview(anyString(), any(Path.class), any())).thenReturn(claudeResult);
+
+        when(gitHubApi.createIssue(anyString(), anyString(), anyString(), anyString(), anyList()))
+                .thenThrow(new RuntimeException("API error"));
+
+        boolean result = decompositionService.decompose(issue, issueDetails,
+                Path.of("/tmp/repo"), "timed out");
+
+        assertFalse(result);
+        assertNotEquals(IssueStatus.DECOMPOSED, issue.getStatus());
+    }
+
+    @Test
+    void buildDecompositionPrompt_includesTitleAndBody() {
+        ObjectNode details = createIssueDetails();
+        String prompt = decompositionService.buildDecompositionPrompt(details);
+
+        assertTrue(prompt.contains("Fix the login bug"));
+        assertTrue(prompt.contains("special characters"));
+        assertTrue(prompt.contains("sub-tasks"));
+    }
+
+    private TrackedIssue createIssue() {
+        WatchedRepo repo = new WatchedRepo("owner", "repo");
+        repo.setId(1L);
+        TrackedIssue issue = new TrackedIssue(repo, 42, "Fix the login bug");
+        issue.setId(1L);
+        issue.setStatus(IssueStatus.IN_PROGRESS);
+        issue.setBranchName("issuebot/issue-42-fix-login-bug");
+        issue.setCurrentIteration(2);
+        return issue;
+    }
+
+    private ObjectNode createIssueDetails() {
+        ObjectNode details = objectMapper.createObjectNode();
+        details.put("title", "Fix the login bug");
+        details.put("body", "Users can't log in when password contains special characters");
+        details.putArray("labels");
+        return details;
+    }
+}

--- a/src/test/java/com/dbbaskette/issuebot/service/workflow/IterationManagerTest.java
+++ b/src/test/java/com/dbbaskette/issuebot/service/workflow/IterationManagerTest.java
@@ -3,6 +3,7 @@ package com.dbbaskette.issuebot.service.workflow;
 import com.dbbaskette.issuebot.model.*;
 import com.dbbaskette.issuebot.repository.IterationRepository;
 import com.dbbaskette.issuebot.repository.TrackedIssueRepository;
+import com.dbbaskette.issuebot.repository.WatchedRepoRepository;
 import com.dbbaskette.issuebot.service.claude.ClaudeCodeResult;
 import com.dbbaskette.issuebot.service.event.EventService;
 import com.dbbaskette.issuebot.service.github.GitHubApiClient;
@@ -11,14 +12,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 class IterationManagerTest {
 
     private IterationManager iterationManager;
     private TrackedIssueRepository issueRepository;
+    private WatchedRepoRepository repoRepository;
     private IterationRepository iterationRepository;
     private GitHubApiClient gitHubApi;
     private EventService eventService;
@@ -27,13 +31,17 @@ class IterationManagerTest {
     @BeforeEach
     void setUp() {
         issueRepository = mock(TrackedIssueRepository.class);
+        repoRepository = mock(WatchedRepoRepository.class);
         iterationRepository = mock(IterationRepository.class);
         gitHubApi = mock(GitHubApiClient.class);
         eventService = mock(EventService.class);
         notificationService = mock(NotificationService.class);
 
-        iterationManager = new IterationManager(issueRepository, iterationRepository,
-                gitHubApi, eventService, notificationService);
+        // By default, repoRepository returns empty so canIterate falls back to in-memory values
+        when(repoRepository.findById(any())).thenReturn(Optional.empty());
+
+        iterationManager = new IterationManager(issueRepository, repoRepository,
+                iterationRepository, gitHubApi, eventService, notificationService);
     }
 
     @Test
@@ -90,8 +98,19 @@ class IterationManagerTest {
     }
 
     @Test
-    void shouldSkipRetry_timedOut() {
+    void shouldSkipRetry_timedOut_allowsRetryOnFirstIteration() {
         TrackedIssue issue = createIssue(1);
+        ClaudeCodeResult result = new ClaudeCodeResult();
+        result.setTimedOut(true);
+        result.setSuccess(false);
+
+        String reason = iterationManager.shouldSkipRetry(issue, result, null, null);
+        assertNull(reason); // first iteration timeout should allow one retry
+    }
+
+    @Test
+    void shouldSkipRetry_timedOut_skipsOnSecondIteration() {
+        TrackedIssue issue = createIssue(2);
         ClaudeCodeResult result = new ClaudeCodeResult();
         result.setTimedOut(true);
         result.setSuccess(false);
@@ -102,8 +121,19 @@ class IterationManagerTest {
     }
 
     @Test
-    void shouldSkipRetry_excessiveTokens() {
+    void shouldSkipRetry_excessiveTokens_allowsRetryOnFirstIteration() {
         TrackedIssue issue = createIssue(1);
+        ClaudeCodeResult result = new ClaudeCodeResult();
+        result.setSuccess(false);
+        result.setOutputTokens(200_000);
+
+        String reason = iterationManager.shouldSkipRetry(issue, result, null, null);
+        assertNull(reason); // first iteration should allow one retry
+    }
+
+    @Test
+    void shouldSkipRetry_excessiveTokens_skipsOnSecondIteration() {
+        TrackedIssue issue = createIssue(2);
         ClaudeCodeResult result = new ClaudeCodeResult();
         result.setSuccess(false);
         result.setOutputTokens(200_000);
@@ -125,16 +155,32 @@ class IterationManagerTest {
     }
 
     @Test
-    void shouldSkipRetry_repeatedFailure() {
+    void shouldSkipRetry_repeatedImplFailure() {
         TrackedIssue issue = createIssue(2);
         ClaudeCodeResult result = new ClaudeCodeResult();
         result.setSuccess(false);
         result.setOutputTokens(10_000);
         result.setFilesChanged(java.util.List.of("src/Foo.java")); // made some progress but still failed
 
-        String reason = iterationManager.shouldSkipRetry(issue, result, null, "previous feedback");
+        // Only skips when feedback is a prior impl failure (starts with "Claude Code failed:")
+        String reason = iterationManager.shouldSkipRetry(issue, result, null,
+                "Claude Code failed: compilation error");
         assertNotNull(reason);
         assertTrue(reason.contains("failed again"));
+    }
+
+    @Test
+    void shouldSkipRetry_allowsRetryWithReviewFeedback() {
+        TrackedIssue issue = createIssue(2);
+        ClaudeCodeResult result = new ClaudeCodeResult();
+        result.setSuccess(false);
+        result.setOutputTokens(10_000);
+        result.setFilesChanged(java.util.List.of("src/Foo.java"));
+
+        // Review feedback should NOT cause skip — it's legitimate retry context
+        String reason = iterationManager.shouldSkipRetry(issue, result, null,
+                "## Independent Review Feedback\nMissing test coverage");
+        assertNull(reason);
     }
 
     private TrackedIssue createIssue(int currentIteration) {


### PR DESCRIPTION
Three root causes addressed:
- canIterate() and canReviewIterate() now re-read maxIterations from DB,
  fixing stale values when repo settings change during a running workflow
- shouldSkipRetry() no longer skips on first iteration for timeouts/token
  limits, allowing at least one retry before giving up
- shouldSkipRetry() repeated-failure check now only triggers for actual
  implementation failures (prefix "Claude Code failed:"), not review
  feedback or human instructions that were incorrectly treated as failures
- Iteration loop re-reads TrackedIssue from DB at each iteration start
- Event messages now show "N/M" format (e.g., "Starting iteration 2/5")

Closes #46

https://claude.ai/code/session_01WEF38WhKjG5EEuvcqRy9nU